### PR TITLE
Don't create controllers when building HttpActionDescriptors

### DIFF
--- a/Swashbuckle.OData.Sample/App_Start/CustomNavigationPropertyRoutingConvention.cs
+++ b/Swashbuckle.OData.Sample/App_Start/CustomNavigationPropertyRoutingConvention.cs
@@ -11,7 +11,7 @@ namespace SwashbuckleODataSample
     {
         public override string SelectAction(ODataPath odataPath, HttpControllerContext controllerContext, ILookup<string, HttpActionDescriptor> actionMap)
         {
-            var controllerType = controllerContext.Controller.GetType();
+            var controllerType = controllerContext.ControllerDescriptor.ControllerType;
 
             if (typeof(CustomersController) == controllerType)
             {

--- a/Swashbuckle.OData/Descriptions/SwaggerRouteStrategy.cs
+++ b/Swashbuckle.OData/Descriptions/SwaggerRouteStrategy.cs
@@ -59,7 +59,7 @@ namespace Swashbuckle.OData.Descriptions
             {
                 var request = CreateHttpRequestMessage(httpMethod, potentialOperation, potentialPathTemplate, oDataRoute, httpConfig);
 
-                var actionDescriptor = request.GetHttpActionDescriptor();
+                var actionDescriptor = request.GetHttpActionDescriptor(httpConfig);
 
                 if (actionDescriptor != null)
                 {


### PR DESCRIPTION
If a controller is using dependency injection and does not have a
default parameterless constructor the
controllerDescriptor.CreateController method will fail. This change uses
a different overload of the HttpControllerContext constructor that does
not require a controller to be created in order to extract an
HttpActionDescriptor.