### PR TITLE
Add prefix parameters to swagger operation

### DIFF
--- a/Swashbuckle.OData/Descriptions/EntityDataModelRouteGenerator.cs
+++ b/Swashbuckle.OData/Descriptions/EntityDataModelRouteGenerator.cs
@@ -107,7 +107,7 @@ namespace Swashbuckle.OData.Descriptions
                             var entityType = (IEdmEntityType)boundType;
                             var edmEntitySets = oDataRoute.GetEdmModel().EntityContainer.EntitySets();
                             Contract.Assume(edmEntitySets != null);
-                            routes.AddRange(edmEntitySets.Where(es => es.GetEntityType().Equals(entityType)).Select(entitySet => new SwaggerRoute(ODataSwaggerUtilities.GetPathForOperationOfEntity(operation, entitySet), oDataRoute, ODataSwaggerUtilities.CreateSwaggerPathForOperationOfEntity(operation, entitySet))));
+                            routes.AddRange(edmEntitySets.Where(es => es.GetEntityType().Equals(entityType)).Select(entitySet => new SwaggerRoute(ODataSwaggerUtilities.GetPathForOperationOfEntity(operation, entitySet), oDataRoute, ODataSwaggerUtilities.CreateSwaggerPathForOperationOfEntity(operation, entitySet, oDataRoute))));
                         }
                         else if (boundType.TypeKind == EdmTypeKind.Collection)
                         {

--- a/Swashbuckle.OData/Descriptions/ODataSwaggerUtilities.cs
+++ b/Swashbuckle.OData/Descriptions/ODataSwaggerUtilities.cs
@@ -384,7 +384,7 @@ namespace Swashbuckle.OData.Descriptions
         /// <param name="operation">The Edm operation.</param>
         /// <param name="entitySet">The entity set.</param>
         /// <returns></returns>
-        public static PathItem CreateSwaggerPathForOperationOfEntity(IEdmOperation operation, IEdmEntitySet entitySet)
+        public static PathItem CreateSwaggerPathForOperationOfEntity(IEdmOperation operation, IEdmEntitySet entitySet, ODataRoute oDataRoute)
         {
             Contract.Requires(operation != null);
             Contract.Requires(entitySet != null);
@@ -424,6 +424,7 @@ namespace Swashbuckle.OData.Descriptions
             var swaggerOperation = new Operation()
                 .Summary("Call operation  " + operation.Name)
                 .Description("Call operation  " + operation.Name)
+                .Parameters(AddRoutePrefixParameters(oDataRoute))
                 .Tags(entitySet.Name, isFunction ? "Function" : "Action");
 
             if (swaggerParameters.Count > 0)


### PR DESCRIPTION
Operations on Entities were missing the prefix parameters. This would
cause an unbound variable exception if you had a route prefix and a
function or action bound to an entity.

Note: I put the unit test in FunctionTests. Let me know if it would be more appropriate in ParameterizedRoutePrefixTests.  I was having some issues adding a function in there.

I believe this will resolve #57.