### PR TITLE
Support for Enums types as keys

### DIFF
--- a/Swashbuckle.OData.Sample/App_Start/ODataConfig.cs
+++ b/Swashbuckle.OData.Sample/App_Start/ODataConfig.cs
@@ -58,6 +58,16 @@ namespace SwashbuckleODataSample
 
             // Define a default non- versioned route(default route should be at the end as a last catch-all)
             config.MapODataServiceRoute("DefaultODataRoute", ODataRoutePrefix, GetDefaultModel());
+
+            // Define a route with an enum as a key
+            config.MapODataServiceRoute("EnumODataRoute",
+                                    ODataRoutePrefix,
+                                    GetProductWithEnumKeyModel());
+
+            // Define a route with an enum/int composite key
+            config.MapODataServiceRoute("EnumIntCompositeODataRoute",
+                                        ODataRoutePrefix,
+                                        GetProductWithCompositeEnumIntKeyModel());
         }
 
         private static IEdmModel GetDefaultModel()
@@ -174,5 +184,28 @@ namespace SwashbuckleODataSample
 
             return builder.GetEdmModel();
         }
+
+        #region Enum Routes
+        private static IEdmModel GetProductWithEnumKeyModel()
+        {
+            var builder = new ODataConventionModelBuilder();
+            builder.EnableLowerCamelCase();
+
+            builder.EntitySet<ProductWithEnumKey>("ProductWithEnumKeys");
+
+            return builder.GetEdmModel();
+        }
+
+        private static IEdmModel GetProductWithCompositeEnumIntKeyModel()
+        {
+            var builder = new ODataConventionModelBuilder();
+            builder.EnableLowerCamelCase();
+
+            builder.EntitySet<ProductWithCompositeEnumIntKey>
+                            ("ProductWithCompositeEnumIntKeys");
+
+            return builder.GetEdmModel();
+        }
+        #endregion
     }
 }

--- a/Swashbuckle.OData.Sample/App_Start/WebApiConfig.cs
+++ b/Swashbuckle.OData.Sample/App_Start/WebApiConfig.cs
@@ -1,4 +1,6 @@
-﻿using System.Web.Http;
+﻿using System.Web.Configuration;
+using System.Web.Http;
+using System.Web.OData.Extensions;
 
 namespace SwashbuckleODataSample
 {
@@ -6,6 +8,9 @@ namespace SwashbuckleODataSample
     {
         public static void Register(HttpConfiguration config)
         {
+            bool isPrefixFreeEnabled = System.Convert.ToBoolean(
+                        WebConfigurationManager.AppSettings["EnableEnumPrefixFree"]);
+            config.EnableEnumPrefixFree(isPrefixFreeEnabled);
             config.MapHttpAttributeRoutes();
 
             config.Routes.MapHttpRoute("DefaultApi", "api/{controller}/{id}", new { id = RouteParameter.Optional });

--- a/Swashbuckle.OData.Sample/DocumentFilters/ApplyResourceDocumentation.cs
+++ b/Swashbuckle.OData.Sample/DocumentFilters/ApplyResourceDocumentation.cs
@@ -18,7 +18,9 @@ namespace SwashbuckleODataSample.DocumentFilters
                 new Tag { name = "Orders", description = "an ODataController resource" },
                 new Tag { name = "CustomersV1", description = "a versioned ODataController resource" },
                 new Tag { name = "Users", description = "a RESTier resource" },
-                new Tag { name = "Products", description = "demonstrates OData functions and actions" }
+                new Tag { name = "Products", description = "demonstrates OData functions and actions" },
+                new Tag { name = "ProductWithCompositeEnumIntKeys", description = "demonstrates composite keys with an enum as a key" },
+                new Tag { name = "ProductWithEnumKeys", description = "demonstrates use of enum as a key" },
             };
         }
     }

--- a/Swashbuckle.OData.Sample/Models/ProductWithEnumKey.cs
+++ b/Swashbuckle.OData.Sample/Models/ProductWithEnumKey.cs
@@ -1,0 +1,27 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace SwashbuckleODataSample.Models
+{
+    public class ProductWithEnumKey
+    {
+        [Key]
+        public MyEnum EnumValue { get; set; }
+
+        public string Name { get; set; }
+
+        public double Price { get; set; }
+    }
+
+    public class ProductWithCompositeEnumIntKey
+    {
+        [Key]
+        public MyEnum EnumValue { get; set; }
+
+        [Key]
+        public int Id { get; set; }
+
+        public string Name { get; set; }
+
+        public double Price { get; set; }
+    }
+}

--- a/Swashbuckle.OData.Sample/ODataControllers/ProductWithCompositeEnumIntKeysController.cs
+++ b/Swashbuckle.OData.Sample/ODataControllers/ProductWithCompositeEnumIntKeysController.cs
@@ -1,0 +1,62 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Web.Http;
+using System.Web.OData;
+using SwashbuckleODataSample.Models;
+using System;
+
+namespace SwashbuckleODataSample.ODataControllers
+{
+    public class ProductWithCompositeEnumIntKeysController : ODataController
+    {
+        private static readonly List<ProductWithCompositeEnumIntKey> DataCompositeKey;
+
+        static ProductWithCompositeEnumIntKeysController()
+        {
+            DataCompositeKey = new List<ProductWithCompositeEnumIntKey>()
+            {
+                {
+                    new ProductWithCompositeEnumIntKey
+                    {
+                        EnumValue = MyEnum.ValueOne,
+                        Id = 1,
+                        Name = "ValueOneName",
+                        Price = 101
+                    }
+                },
+                {
+                    new ProductWithCompositeEnumIntKey
+                    {
+                        EnumValue = MyEnum.ValueTwo,
+                        Id = 2,
+                        Name = "ValueTwoName",
+                        Price = 102
+                    }
+                }
+            };
+        }
+
+        /// <summary>
+        /// Query products
+        /// </summary>
+        [EnableQuery]
+        public IQueryable<ProductWithCompositeEnumIntKey> Get()
+        {
+            return DataCompositeKey.AsQueryable();
+        }
+
+        /// <summary>
+        /// Query products by keys
+        /// </summary>
+        /// <param name="keyenumValue">key enum value</param>
+        /// <param name="keyid">key id</param>
+        /// <returns>composite enum-int key model</returns>
+        [EnableQuery]
+        public IHttpActionResult Get([FromODataUri]MyEnum keyenumValue, [FromODataUri]int keyid)
+        {
+            return Ok(DataCompositeKey
+                        .Where(x => x.EnumValue == keyenumValue 
+                                    && x.Id == keyid));
+        }
+    }
+}

--- a/Swashbuckle.OData.Sample/ODataControllers/ProductWithEnumKeysController.cs
+++ b/Swashbuckle.OData.Sample/ODataControllers/ProductWithEnumKeysController.cs
@@ -1,0 +1,59 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Web.Http;
+using System.Web.OData;
+using SwashbuckleODataSample.Models;
+
+namespace SwashbuckleODataSample.ODataControllers
+{
+    public class ProductWithEnumKeysController : ODataController
+    {
+        private static readonly Dictionary<MyEnum, 
+                                    ProductWithEnumKey> DataEnumAsKey;
+
+        static ProductWithEnumKeysController()
+        {
+            DataEnumAsKey = new Dictionary<MyEnum, ProductWithEnumKey>()
+            {
+                {
+                    MyEnum.ValueOne,
+                    new ProductWithEnumKey {
+                        EnumValue = MyEnum.ValueOne,
+                        Name = "ValueOneName",
+                        Price = 101
+                    }
+                },
+                {
+                    MyEnum.ValueTwo,
+                    new ProductWithEnumKey
+                    {
+                        EnumValue = MyEnum.ValueTwo,
+                        Name = "ValueTwoName",
+                        Price = 102
+                    }
+                }
+            };
+        }
+
+        /// <summary>
+        /// Query products
+        /// </summary>
+        [HttpGet]
+        [EnableQuery]
+        public IQueryable<ProductWithEnumKey> Get()
+        {
+            return DataEnumAsKey.Values.AsQueryable();
+        }
+
+        /// <summary>
+        /// Query product by enum key
+        /// </summary>
+        /// <param name="Key">key enum value</param>
+        /// <returns>project enum model</returns>
+        [HttpGet]
+        public IHttpActionResult Get([FromODataUri]MyEnum Key)
+        {
+            return Ok(DataEnumAsKey[Key]);
+        }
+    }
+}

--- a/Swashbuckle.OData.Sample/Swashbuckle.OData.Sample.csproj
+++ b/Swashbuckle.OData.Sample/Swashbuckle.OData.Sample.csproj
@@ -146,6 +146,9 @@
     <Compile Include="DocumentFilters\ApplyResourceDocumentation.cs" />
     <Compile Include="Models\MyEnum.cs" />
     <Compile Include="Models\Product.cs" />
+    <Compile Include="Models\ProductWithEnumKey.cs" />
+    <Compile Include="ODataControllers\ProductWithCompositeEnumIntKeysController.cs" />
+    <Compile Include="ODataControllers\ProductWithEnumKeysController.cs" />
     <Compile Include="ODataControllers\ProductsController.cs" />
     <Compile Include="Repositories\RestierODataContext.cs" />
     <Compile Include="Models\User.cs" />

--- a/Swashbuckle.OData.Sample/Web.config
+++ b/Swashbuckle.OData.Sample/Web.config
@@ -64,4 +64,7 @@
       <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="*" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0" />
     </handlers>
 </system.webServer>
+  <appSettings>
+    <add key="EnableEnumPrefixFree" value="false" />
+  </appSettings>
 </configuration>

--- a/Swashbuckle.OData.Tests/Fixtures/ParameterKeyTests.cs
+++ b/Swashbuckle.OData.Tests/Fixtures/ParameterKeyTests.cs
@@ -1,0 +1,338 @@
+﻿using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Web.Http;
+using System.Web.OData;
+using System.Web.OData.Builder;
+using System.Web.OData.Extensions;
+using FluentAssertions;
+using Microsoft.OData.Edm;
+using Microsoft.Owin.Hosting;
+using NUnit.Framework;
+using Owin;
+using Swashbuckle.Swagger;
+using SwashbuckleODataSample.Models;
+
+
+namespace Swashbuckle.OData.Tests
+{
+    [TestFixture]
+    public class ParameterKeyTests
+    {
+        private const string ODataRoutePrefix = "odata";
+        private const string EnumKeyEndpointName = "ProductWithEnumKeysTest";
+        private const string CompositeKeyEndpointName = "ProductWithCompositeEnumIntKeysTest";
+
+        private const string EnumNamespace = "SwashbuckleODataSample.Models.MyEnum";
+        private const string EnumKeyName = "enumValue";
+        private const string IdKeyName = "id";
+
+        [Test]
+        public async Task It_supports_enum_key_issue_108()
+        {
+            using (WebApp.Start(HttpClientUtils.BaseAddress,
+                                appBuilder => ConfigurationEnumKey(appBuilder, true))
+            )
+            {
+                // Arrange
+                var httpClient = HttpClientUtils.GetHttpClient(HttpClientUtils.BaseAddress);
+
+                // Verify that the OData route in the test controller is valid
+                var response = await httpClient.GetAsync($"/{ODataRoutePrefix}/{EnumKeyEndpointName}");
+                await response.ValidateSuccessAsync();
+
+                // Act
+                var swaggerDocument = await httpClient.GetJsonAsync<SwaggerDocument>("swagger/docs/v1");
+
+                // Assert
+                PathItem pathItem;
+                var testEndpoint = $"/{ODataRoutePrefix}/{EnumKeyEndpointName}('{{{EnumKeyName}}}')";
+                swaggerDocument.paths.TryGetValue(testEndpoint, out pathItem);
+                pathItem.Should().NotBeNull();
+
+                // Assert Enum Pararemter
+                var enumParamter = pathItem?.@get.parameters.SingleOrDefault(p => p.name == EnumKeyName);
+                enumParamter.Should().NotBeNull();
+                enumParamter?.@enum.Should().NotBeEmpty();
+                enumParamter?.@in.Should().Be("path");
+                enumParamter?.@type.Should().Be("string");
+                enumParamter?.required.ShouldBeEquivalentTo(true);
+
+                await ValidationUtils.ValidateSwaggerJson();
+            }
+        }
+
+        [Test]
+        public async Task It_supports_enum_as_key_with_enum_prefix_issue_108()
+        {
+            using (WebApp.Start(HttpClientUtils.BaseAddress,
+                                appBuilder => ConfigurationEnumKey(appBuilder, false))
+            )
+            {
+                // Arrange
+                var httpClient = HttpClientUtils.GetHttpClient(HttpClientUtils.BaseAddress);
+
+                // Verify that the OData route in the test controller is valid
+                var response = await httpClient.GetAsync($"/{ODataRoutePrefix}/{EnumKeyEndpointName}");
+                await response.ValidateSuccessAsync();
+
+                // Act
+                var swaggerDocument = await httpClient.GetJsonAsync<SwaggerDocument>("swagger/docs/v1");
+
+                // Assert
+                PathItem pathItem;
+                var testEndpoint = $"/{ODataRoutePrefix}/{EnumKeyEndpointName}({EnumNamespace}'{{{EnumKeyName}}}')";
+                swaggerDocument.paths.TryGetValue(testEndpoint, out pathItem);
+                pathItem.Should().NotBeNull();
+
+                await ValidationUtils.ValidateSwaggerJson();
+            }
+        }
+
+        [Test]
+        public async Task It_supports_composite_key_with_enum_issue_108()
+        {
+            using (WebApp.Start(HttpClientUtils.BaseAddress,
+                                appBuilder => ConfigurationCompositeKey(appBuilder, true))
+            )
+            {
+                // Arrange
+                var httpClient = HttpClientUtils.GetHttpClient(HttpClientUtils.BaseAddress);
+
+                // Verify that the OData route in the test controller is valid
+                var response = await httpClient.GetAsync($"/{ODataRoutePrefix}/{CompositeKeyEndpointName}");
+                await response.ValidateSuccessAsync();
+
+                // Act
+                var swaggerDocument = await httpClient.GetJsonAsync<SwaggerDocument>("swagger/docs/v1");
+
+                // Assert
+                PathItem pathItem;
+                var testEndpoint = $"/{ODataRoutePrefix}/{CompositeKeyEndpointName}({IdKeyName}={{{IdKeyName}}},{EnumKeyName}='{{{EnumKeyName}}}')";
+                swaggerDocument.paths.TryGetValue(testEndpoint, out pathItem);
+                pathItem.Should().NotBeNull();
+
+                // Assert Enum Pararemter
+                var enumParamter = pathItem?.@get.parameters.SingleOrDefault(p => p.name == EnumKeyName);
+                enumParamter.Should().NotBeNull();
+                enumParamter?.@enum.Should().NotBeEmpty();
+                enumParamter?.@in.Should().Be("path");
+                enumParamter?.@type.Should().Be("string");
+                enumParamter?.required.ShouldBeEquivalentTo(true);
+
+                // Assert Id Pararemter
+                var idParamter = pathItem?.@get.parameters.SingleOrDefault(p => p.name == IdKeyName);
+                idParamter.Should().NotBeNull();
+                idParamter?.@in.Should().Be("path");
+                idParamter?.@type.Should().Be("integer");
+                idParamter?.required.ShouldBeEquivalentTo(true);
+
+                await ValidationUtils.ValidateSwaggerJson();
+            }
+        }
+
+        [Test]
+        public async Task It_supports_composite_key_with_enum_no_enum_prefix_issue_108()
+        {
+            using (WebApp.Start(HttpClientUtils.BaseAddress,
+                                appBuilder => ConfigurationCompositeKey(appBuilder, false))
+            )
+            {
+                // Arrange
+                var httpClient = HttpClientUtils.GetHttpClient(HttpClientUtils.BaseAddress);
+
+                // Verify that the OData route in the test controller is valid
+                var response = await httpClient.GetAsync($"/{ODataRoutePrefix}/{CompositeKeyEndpointName}");
+                await response.ValidateSuccessAsync();
+
+                // Act
+                var swaggerDocument = await httpClient.GetJsonAsync<SwaggerDocument>("swagger/docs/v1");
+
+                // Assert
+                PathItem pathItem;
+                var testEndpoint = $"/{ODataRoutePrefix}/{CompositeKeyEndpointName}({IdKeyName}={{{IdKeyName}}},{EnumKeyName}={EnumNamespace}'{{{EnumKeyName}}}')";
+                swaggerDocument.paths.TryGetValue(testEndpoint, out pathItem);
+                pathItem.Should().NotBeNull();
+
+                await ValidationUtils.ValidateSwaggerJson();
+            }
+        }
+
+        private static void ConfigurationEnumKey(IAppBuilder appBuilder, bool isEnumPrefixFree)
+        {
+            var config = appBuilder.GetStandardHttpConfig(typeof(ProductWithEnumKeysTestController));
+            config.EnableEnumPrefixFree(isEnumPrefixFree);
+
+            config.MapODataServiceRoute("EnumKeyODataRoute",
+                                        ODataRoutePrefix,
+                                        GetProductWithEnumKeyModel());
+
+            config.EnsureInitialized();
+        }
+
+        private static void ConfigurationCompositeKey(IAppBuilder appBuilder, bool isEnumPrefixFree)
+        {
+            var config = appBuilder.GetStandardHttpConfig(typeof(ProductWithCompositeEnumIntKeysTestController));
+            config.EnableEnumPrefixFree(isEnumPrefixFree);
+
+            config.MapODataServiceRoute("CompositeKeyODataRoute",
+                                        ODataRoutePrefix,
+                                        GetProductWithCompositeEnumIntKeyModel());
+
+            config.EnsureInitialized();
+        }
+
+        private static IEdmModel GetProductWithEnumKeyModel()
+        {
+            var builder = new ODataConventionModelBuilder();
+            builder.EnableLowerCamelCase();
+
+            builder.EntitySet<ProductWithEnumKey>("ProductWithEnumKeysTest");
+
+            return builder.GetEdmModel();
+        }
+
+        private static IEdmModel GetProductWithCompositeEnumIntKeyModel()
+        {
+            var builder = new ODataConventionModelBuilder();
+            builder.EnableLowerCamelCase();
+
+            builder.EntitySet<ProductWithCompositeEnumIntKey>
+                                            ("ProductWithCompositeEnumIntKeysTest");
+
+            return builder.GetEdmModel();
+        }
+    }
+
+    #region Models
+    public class ProductWithEnumKey
+    {
+        [Key]
+        public SwashbuckleODataSample.Models.MyEnum EnumValue { get; set; }
+
+        public string Name { get; set; }
+
+        public double Price { get; set; }
+    }
+
+    public class ProductWithCompositeEnumIntKey
+    {
+        [Key]
+        public MyEnum EnumValue { get; set; }
+
+        [Key]
+        public int Id { get; set; }
+
+        public string Name { get; set; }
+
+        public double Price { get; set; }
+    }
+    #endregion
+
+    #region ODataControllers
+    public class ProductWithEnumKeysTestController : ODataController
+    {
+        private static readonly Dictionary<MyEnum,
+                                    ProductWithEnumKey> DataEnumAsKey;
+
+        static ProductWithEnumKeysTestController()
+        {
+            DataEnumAsKey = new Dictionary<MyEnum, ProductWithEnumKey>()
+            {
+                {
+                    MyEnum.ValueOne,
+                    new ProductWithEnumKey {
+                        EnumValue = MyEnum.ValueOne,
+                        Name = "ValueOneName",
+                        Price = 101
+                    }
+                },
+                {
+                    MyEnum.ValueTwo,
+                    new ProductWithEnumKey
+                    {
+                        EnumValue = MyEnum.ValueTwo,
+                        Name = "ValueTwoName",
+                        Price = 102
+                    }
+                }
+            };
+        }
+
+        /// <summary>
+        /// Query products
+        /// </summary>
+        [HttpGet]
+        [EnableQuery]
+        public IQueryable<ProductWithEnumKey> Get()
+        {
+            return DataEnumAsKey.Values.AsQueryable();
+        }
+
+        /// <summary>
+        /// Query product by enum key
+        /// </summary>
+        /// <param name="Key">key enum value</param>
+        /// <returns>project enum model</returns>
+        [HttpGet]
+        public IHttpActionResult Get([FromODataUri]MyEnum Key)
+        {
+            return Ok(DataEnumAsKey[Key]);
+        }
+    }
+
+    public class ProductWithCompositeEnumIntKeysTestController : ODataController
+    {
+        private static readonly List<ProductWithCompositeEnumIntKey> DataCompositeKey;
+
+        static ProductWithCompositeEnumIntKeysTestController()
+        {
+            DataCompositeKey = new List<ProductWithCompositeEnumIntKey>()
+            {
+                {
+                    new ProductWithCompositeEnumIntKey
+                    {
+                        EnumValue = MyEnum.ValueOne,
+                        Id = 1,
+                        Name = "ValueOneName",
+                        Price = 101
+                    }
+                },
+                {
+                    new ProductWithCompositeEnumIntKey
+                    {
+                        EnumValue = MyEnum.ValueTwo,
+                        Id = 2,
+                        Name = "ValueTwoName",
+                        Price = 102
+                    }
+                }
+            };
+        }
+
+        /// <summary>
+        /// Query products
+        /// </summary>
+        [EnableQuery]
+        public IQueryable<ProductWithCompositeEnumIntKey> Get()
+        {
+            return DataCompositeKey.AsQueryable();
+        }
+
+        /// <summary>
+        /// Query products by keys
+        /// </summary>
+        /// <param name="keyenumValue">key enum value</param>
+        /// <param name="keyid">key id</param>
+        /// <returns>composite enum-int key model</returns>
+        [EnableQuery]
+        public IHttpActionResult Get([FromODataUri]MyEnum keyenumValue, [FromODataUri]int keyid)
+        {
+            return Ok(DataCompositeKey
+                        .Where(x => x.EnumValue == keyenumValue
+                                    && x.Id == keyid));
+        }
+    }
+    #endregion
+}

--- a/Swashbuckle.OData.Tests/Fixtures/RestierTests.cs
+++ b/Swashbuckle.OData.Tests/Fixtures/RestierTests.cs
@@ -173,7 +173,7 @@ namespace Swashbuckle.OData.Tests
 
                 // Assert
                 PathItem pathItem;
-                swaggerDocument.paths.TryGetValue("/restier/OrderDetails(OrderId={OrderId}, ProductId={ProductId})", out pathItem);
+                swaggerDocument.paths.TryGetValue("/restier/OrderDetails(OrderId={OrderId},ProductId={ProductId})", out pathItem);
                 pathItem.Should().NotBeNull();
                 var getResponse = pathItem.get.responses.SingleOrDefault(response => response.Key == "200");
                 getResponse.Should().NotBeNull();

--- a/Swashbuckle.OData.Tests/Swashbuckle.OData.Tests.csproj
+++ b/Swashbuckle.OData.Tests/Swashbuckle.OData.Tests.csproj
@@ -167,6 +167,7 @@
     <Compile Include="Fixtures\RestierTests.cs" />
     <Compile Include="Fixtures\SchemaTests.cs" />
     <Compile Include="Fixtures\ResponseModelTests.cs" />
+    <Compile Include="Fixtures\ParameterKeyTests.cs" />
     <Compile Include="Fixtures\StringTypeUrlParamTests.cs" />
     <Compile Include="HttpClientUtils.cs" />
     <Compile Include="Fixtures\GetTests.cs" />

--- a/Swashbuckle.OData/Descriptions/EntityDataModelRouteGenerator.cs
+++ b/Swashbuckle.OData/Descriptions/EntityDataModelRouteGenerator.cs
@@ -19,6 +19,7 @@ namespace Swashbuckle.OData.Descriptions
     {
         public IEnumerable<SwaggerRoute> Generate(HttpConfiguration httpConfig)
         {
+            ODataSwaggerUtilities.SetHttpConfig(httpConfig);
             return httpConfig.GetODataRoutes().SelectMany(Generate);
         }
 

--- a/Swashbuckle.OData/Descriptions/MapByDescription.cs
+++ b/Swashbuckle.OData/Descriptions/MapByDescription.cs
@@ -2,17 +2,41 @@ using System.Diagnostics.Contracts;
 using System.Linq;
 using System.Web.Http.Controllers;
 using Swashbuckle.Swagger;
+using System;
 
 namespace Swashbuckle.OData.Descriptions
 {
     internal class MapByDescription : IParameterMapper
     {
+        /// <summary>
+        /// The name for parameter keys in the route.
+        /// </summary>
+        private const string KeyName = "key";
+
+        /// <summary>
+        /// Swagger description substring dividing the key from the paramter name.
+        /// </summary>
+        private const string FindKeyReplacementSubStr = ": ";
+
         public HttpParameterDescriptor Map(Parameter swaggerParameter, int parameterIndex, HttpActionDescriptor actionDescriptor)
         {
             // Maybe the parameter is a key parameter, e.g., where Id in the URI path maps to a parameter named 'key'
             if (swaggerParameter.description != null && swaggerParameter.description.StartsWith("key:"))
             {
-                var parameterDescriptor = actionDescriptor.GetParameters()?.SingleOrDefault(descriptor => descriptor.ParameterName == "key");
+                // Find either a single 'key' in the route or composite keys
+                // which take the form of key<parameter name>
+                var keyParameterName = swaggerParameter
+                                        .description
+                                        .Replace(FindKeyReplacementSubStr, 
+                                                    String.Empty)
+                                        .ToLower();
+                var parameterDescriptor = 
+                    actionDescriptor
+                        .GetParameters()?
+                        .SingleOrDefault(descriptor =>
+                            descriptor.ParameterName.ToLower() == KeyName
+                            || descriptor.ParameterName.ToLower().Equals(keyParameterName)
+                        );
                 if (parameterDescriptor != null && !parameterDescriptor.IsODataLibraryType())
                 {
                     var httpControllerDescriptor = actionDescriptor.ControllerDescriptor;

--- a/Swashbuckle.OData/Descriptions/ODataSwaggerUtilities.cs
+++ b/Swashbuckle.OData/Descriptions/ODataSwaggerUtilities.cs
@@ -13,6 +13,7 @@ using Microsoft.OData.Edm;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using Swashbuckle.Swagger;
+using System.Web.Http;
 
 namespace Swashbuckle.OData.Descriptions
 {
@@ -21,6 +22,38 @@ namespace Swashbuckle.OData.Descriptions
     /// </summary>
     internal static class ODataSwaggerUtilities
     {
+        /// <summary>
+        /// HttpConfiguration for ODataSwaggerUtilities
+        /// </summary>
+        public static HttpConfiguration HttpConfig = null;
+
+        /// <summary>
+        /// Resolver Settings Key namespace
+        /// </summary>
+        private const string ResolverSettingsKey 
+                        = "System.Web.OData.ResolverSettingsKey";
+
+        /// <summary>
+        /// Enum Prefix Free property name
+        /// </summary>
+        private const string EnumPrefixFree = "EnumPrefixFree";
+
+        /// <summary>
+        /// The ending Path offset
+        /// </summary>
+        private const int EntityPathSubStrOffset = 1;
+
+        /// <summary>
+        /// Sets the HttpConfig static variable for use in the 
+        /// ODataSwaggerUtilities class.
+        /// </summary>
+        /// <param name="httpConfig"></param>
+        public static void SetHttpConfig(HttpConfiguration httpConfig)
+        {
+            Contract.Requires(httpConfig != null);
+            HttpConfig = httpConfig;
+        }
+
         /// <summary>
         /// Create the Swagger path for the Edm entity set.
         /// </summary>
@@ -164,11 +197,27 @@ namespace Swashbuckle.OData.Descriptions
             foreach (var key in entitySet.GetEntityType().GetKey())
             {
                 Contract.Assume(key != null);
-                string format;
-                var keyDefinition = key.GetPropertyType().GetDefinition() as IEdmPrimitiveType;
-                Contract.Assume(keyDefinition != null);
-                var type = GetPrimitiveTypeAndFormat(keyDefinition, out format);
-                keyParameters.Parameter(key.Name, "path", "key: " + key.Name, type, true, format);
+
+                // Create key parameters for primitive and enum types
+                IEdmType keyDefinitionAsType = null;
+                var keyDefinition = key.GetPropertyType().GetDefinition();
+
+                if (EdmTypeKind.Primitive == keyDefinition.TypeKind)
+                {
+                    keyDefinitionAsType = keyDefinition as IEdmPrimitiveType;
+                }
+                else if(EdmTypeKind.Enum == keyDefinition.TypeKind)
+                { 
+                    keyDefinitionAsType = keyDefinition as IEdmEnumType;
+                }
+                Contract.Assume(keyDefinitionAsType != null);
+                
+                keyParameters.Parameter(
+                                key.Name, 
+                                "path", 
+                                "key: " + key.Name, 
+                                keyDefinitionAsType, 
+                                true);
             }
 
             return new PathItem
@@ -469,8 +518,8 @@ namespace Swashbuckle.OData.Descriptions
             singleEntityPath = entitySet.GetEntityType().GetKey().Count() == 1
                 ? AppendSingleColumnKeyTemplate(entitySet, singleEntityPath)
                 : AppendMultiColumnKeyTemplate(entitySet, singleEntityPath);
-            Contract.Assume(singleEntityPath.Length - 2 >= 0);
-            singleEntityPath = singleEntityPath.Substring(0, singleEntityPath.Length - 2);
+            Contract.Assume(singleEntityPath.Length - EntityPathSubStrOffset >= 0);
+            singleEntityPath = singleEntityPath.Substring(0, singleEntityPath.Length - EntityPathSubStrOffset);
             singleEntityPath += ")";
 
             return singleEntityPath;
@@ -482,7 +531,7 @@ namespace Swashbuckle.OData.Descriptions
             Contract.Ensures(Contract.Result<string>() != null);
 
             var key = entitySet.GetEntityType().GetKey().Single();
-            singleEntityPath += "{" + key.Name + "}, ";
+            singleEntityPath += GetParameterPathAssignment(key.Name, key.Type, false);
             return singleEntityPath;
         }
 
@@ -493,7 +542,7 @@ namespace Swashbuckle.OData.Descriptions
             foreach (var key in entitySet.GetEntityType().GetKey())
             {
                 Contract.Assume(key != null);
-                singleEntityPath += key.Name + "={" + key.Name + "}, ";
+                singleEntityPath += GetParameterPathAssignment(key.Name, key.Type, true);
             }
             Contract.Assume(singleEntityPath != null);
             return singleEntityPath;
@@ -570,12 +619,39 @@ namespace Swashbuckle.OData.Descriptions
         {
             Contract.Requires(parameter != null);
 
-            switch (parameter.Type.Definition.TypeKind)
+            return GetParameterPathAssignment(parameter.Name, parameter.Type, true);
+        }
+
+        /// <summary>
+        /// Path builder for endpoint parameters.
+        /// </summary>
+        /// <param name="parameterName">parameter's name</param>
+        /// <param name="type">iedmtype of the parameter</param>
+        /// <param name="isIncludeParamName">true to include the parameter name in the path</param>
+        /// <returns></returns>
+        private static string GetParameterPathAssignment(string parameterName, IEdmTypeReference type, bool isIncludeParamName)
+        {
+            Contract.Requires(parameterName != null);
+            Contract.Requires(type != null);
+            const string paramNamePrefixFormat = "{0}=";
+
+            string parameterPrefix = String.Empty;
+            if (isIncludeParamName)
+            {
+                parameterPrefix = String.Format(paramNamePrefixFormat, parameterName);
+            }
+            
+            switch (type.Definition.TypeKind)
             {
                 case EdmTypeKind.Enum:
-                    return parameter.Name + "=" + parameter.Type.FullName() + "\'{" + parameter.Name + "}\',";
+                    string enumFullName = type.FullName();
+                    if (IsEnableEnumPrefixFree())
+                    {
+                        enumFullName = String.Empty;
+                    }
+                    return parameterPrefix + enumFullName + "\'{" + parameterName + "}\',";
                 default:
-                    return parameter.Name + "=" + "{" + parameter.Name + "},";
+                    return parameterPrefix + "{" + parameterName + "},";
             }
         }
 
@@ -912,6 +988,26 @@ namespace Swashbuckle.OData.Descriptions
             var result = JsonConvert.DeserializeObject<T>(JsonConvert.SerializeObject(source, serializerSettings), serializerSettings);
             Contract.Assume(result != null);
             return result;
+        }
+
+        /// <summary>
+        /// Gets the value of the EnumPrefixFree setting in the HttpConfiguration
+        /// </summary>
+        /// <returns>EnumPrefixFree value</returns>
+        private static bool IsEnableEnumPrefixFree()
+        {
+            Contract.Requires(HttpConfig != null);
+            Contract.Ensures(Contract.Result<bool>().GetType() == typeof(bool));
+
+            var odataUriResolverSettings = HttpConfig
+                                    .Properties
+                                    .Where(prop =>
+                                        prop.Key.Equals(ResolverSettingsKey))
+                                    .FirstOrDefault().Value;
+            return Convert.ToBoolean(odataUriResolverSettings
+                                    .GetType()
+                                    .GetProperty(EnumPrefixFree)
+                                    .GetValue(odataUriResolverSettings));
         }
     }
 }

--- a/coverage.bat
+++ b/coverage.bat
@@ -1,5 +1,9 @@
-.\packages\OpenCover.4.6.166\tools\OpenCover.Console.exe -register:user "-filter:+[Swashbuckle.OData]* -[Swashbuckle.OData]System.*" "-target:.\packages\NUnit.Runners.2.6.4\tools\nunit-console-x86.exe" "-targetargs:/noshadow .\Swashbuckle.OData.Tests\bin\Debug\Swashbuckle.OData.Tests.dll"
+set OpenCoverVersion=4.6.519
+set ReportGeneratorVersion=2.4.3.0
+set NUnitRunnersVersion=2.6.4
 
-.\packages\ReportGenerator.2.3.5.0\tools\ReportGenerator.exe "-reports:results.xml" "-targetdir:.\coverage"
+.\packages\OpenCover.%OpenCoverVersion%\tools\OpenCover.Console.exe -register:user "-filter:+[Swashbuckle.OData]* -[Swashbuckle.OData]System.*" "-target:.\packages\NUnit.Runners.%NUnitRunnersVersion%\tools\nunit-console-x86.exe" "-targetargs:/noshadow .\Swashbuckle.OData.Tests\bin\Debug\Swashbuckle.OData.Tests.dll"
+
+.\packages\ReportGenerator.%ReportGeneratorVersion%\tools\ReportGenerator.exe "-reports:results.xml" "-targetdir:.\coverage"
 
 pause


### PR DESCRIPTION
For the issue 108 filed: https://github.com/rbeauchamp/Swashbuckle.OData/issues/108
Changes were more involved than the patches after testing.  Modification were made to:
- Allow enum types in the path parameters with support for the HttpConfiguration EnumPrefixFree property
- Space removed after the comma between the path parameters due to use of a common method
- key mapping changes to detect case-insensitive 'key' and composite key format of 'key<parametername>'
- Example and unit tests added.
Ran all unit tests which passed.