### PR TITLE
Use the Ignore attribute's reason instead of a comment

### DIFF
--- a/Swashbuckle.OData.Tests/Fixtures/ParameterTests/DecimalParameterAndResponseTests.cs
+++ b/Swashbuckle.OData.Tests/Fixtures/ParameterTests/DecimalParameterAndResponseTests.cs
@@ -20,8 +20,7 @@ namespace Swashbuckle.OData.Tests
     [TestFixture]
     public class DecimalParameterAndResponseTests
     {
-        // Test is broken because of https://github.com/OData/WebApi/issues/813
-        [Test, Ignore]
+        [Test, Ignore("Broken because of https://github.com/OData/WebApi/issues/813")]
         public async Task It_supports_entity_with_a_decimal_key()
         {
             using (WebApp.Start(HttpClientUtils.BaseAddress, appBuilder => Configuration(appBuilder, typeof(DecimalParametersController))))
@@ -45,8 +44,7 @@ namespace Swashbuckle.OData.Tests
             }
         }
 
-        // Test is broken because of https://github.com/OData/WebApi/issues/813
-        [Test, Ignore]
+        [Test, Ignore("Broken because of https://github.com/OData/WebApi/issues/813")]
         public async Task It_supports_functions_with_a_decimal_parameter()
         {
             using (WebApp.Start(HttpClientUtils.BaseAddress, appBuilder => Configuration(appBuilder, typeof(DecimalParametersController))))


### PR DESCRIPTION
This gives test runners the opportunity to display the reason why the test is ignored.

![Test Ignore Reason](https://cloud.githubusercontent.com/assets/51363/24949800/2cf86f80-1f6f-11e7-986c-0bb99b0ec5f3.png)
