### PR TITLE
Assemblies Resolver changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,18 @@ c.CustomProvider(defaultProvider => new ODataSwaggerProvider(defaultProvider, c,
                     }));
 ```
 
+### Assemblies Resolver dependency injection for OData Models ###
+
+Configuration example to inject your own [IAssembliesResolver](https://msdn.microsoft.com/en-us/library/system.web.http.dispatcher.iassembliesresolver(v=vs.118).aspx) instead of using [DefaultAssembliesResolver](https://msdn.microsoft.com/en-us/library/system.web.http.dispatcher.defaultassembliesresolver(v=vs.118).aspx):
+
+```csharp
+c.CustomProvider(defaultProvider => new ODataSwaggerProvider(defaultProvider, c, GlobalConfiguration.Configuration).Configure(odataConfig =>
+                    {
+                        //Set custom AssembliesResolver
+                        odataConfig.SetAssembliesResolver(new CustomAssembliesResolver());
+                    }));
+```
+
 ### Custom Swagger Routes ###
 
 The following snippet demonstrates how to configure a custom swagger route such that it will appear in the Swagger UI:

--- a/Swashbuckle.OData.Sample/App_Start/SwaggerConfig.cs
+++ b/Swashbuckle.OData.Sample/App_Start/SwaggerConfig.cs
@@ -178,8 +178,11 @@ namespace SwashbuckleODataSample
                         //
                         odataConfig.IncludeNavigationProperties();
 
-                        // Enable Caché for swagger doc requests
-                        odataConfig.EnableSwaggerRequestCaching();
+                        // Enable Cache for swagger doc requests
+                        odataConfig.EnableSwaggerRequestCaching();                        
+
+                        //Set custom AssembliesResolver
+                        odataConfig.SetAssembliesResolver(new Utils.CustomAssembliesResolver());
                     }));
             })
                 .EnableSwaggerUi(c =>

--- a/Swashbuckle.OData.Sample/Swashbuckle.OData.Sample.csproj
+++ b/Swashbuckle.OData.Sample/Swashbuckle.OData.Sample.csproj
@@ -91,8 +91,8 @@
       <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Swashbuckle.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=cd1bb07a5ac7c7bc, processorArchitecture=MSIL">
@@ -171,6 +171,7 @@
     <Compile Include="Repositories\SwashbuckleODataContext.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Repositories\TestDbSet.cs" />
+    <Compile Include="Utils\CustomAssembliesResolver.cs" />
     <Compile Include="Utils\SequentialGuidGenerator.cs" />
     <Compile Include="Versioning\ModelValidationFilterAttribute.cs" />
     <Compile Include="Versioning\ODataHelper.cs" />

--- a/Swashbuckle.OData.Sample/Utils/CustomAssembliesResolver.cs
+++ b/Swashbuckle.OData.Sample/Utils/CustomAssembliesResolver.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+using System.Reflection;
+using System.Web.Http.Dispatcher;
+
+namespace SwashbuckleODataSample.Utils
+{
+    /// <summary>
+    /// Custom Assemblies Resolver, using the default assemblies resolver, only for demonstration purposes
+    /// </summary>
+    public class CustomAssembliesResolver : DefaultAssembliesResolver
+    {
+        public override ICollection<Assembly> GetAssemblies()
+        {
+            ICollection<Assembly> baseAssemblies = base.GetAssemblies();
+            return baseAssemblies;
+        }
+    }
+}

--- a/Swashbuckle.OData.Sample/Web.config
+++ b/Swashbuckle.OData.Sample/Web.config
@@ -17,7 +17,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" culture="neutral" publicKeyToken="30ad4fe6b2a6aeed" />
-        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Web.Http" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/Swashbuckle.OData.Sample/packages.config
+++ b/Swashbuckle.OData.Sample/packages.config
@@ -16,7 +16,7 @@
   <package id="Microsoft.Restier.Publishers.OData" version="1.0.0-beta" targetFramework="net452" />
   <package id="Microsoft.Spatial" version="7.0.0" targetFramework="net452" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net452" />
-  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net452" />
   <package id="Swashbuckle" version="5.5.3" targetFramework="net452" />
   <package id="Swashbuckle.Core" version="5.5.3" targetFramework="net452" />
   <package id="WebActivatorEx" version="2.1.0" targetFramework="net452" />

--- a/Swashbuckle.OData.Tests/Swashbuckle.OData.Tests.csproj
+++ b/Swashbuckle.OData.Tests/Swashbuckle.OData.Tests.csproj
@@ -95,8 +95,8 @@
       <HintPath>..\packages\Microsoft.Spatial.7.0.0\lib\portable-net45+win8+wpa81\Microsoft.Spatial.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json.Schema, Version=1.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
@@ -199,7 +199,9 @@
     <Compile Include="ValidationUtils.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config" />
+    <None Include="app.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="schema-draft-v4.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/Swashbuckle.OData.Tests/app.config
+++ b/Swashbuckle.OData.Tests/app.config
@@ -16,7 +16,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/Swashbuckle.OData.Tests/packages.config
+++ b/Swashbuckle.OData.Tests/packages.config
@@ -19,7 +19,7 @@
   <package id="Microsoft.Restier.Providers.EntityFramework" version="1.0.0-beta" targetFramework="net452" />
   <package id="Microsoft.Restier.Publishers.OData" version="1.0.0-beta" targetFramework="net452" />
   <package id="Microsoft.Spatial" version="7.0.0" targetFramework="net452" />
-  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net452" />
   <package id="Newtonsoft.Json.Schema" version="1.0.11" targetFramework="net452" />
   <package id="NUnit" version="2.6.4" targetFramework="net452" />
   <package id="NUnit.Runners" version="2.6.4" targetFramework="net452" />

--- a/Swashbuckle.OData/ODataSwaggerDocsConfig.cs
+++ b/Swashbuckle.OData/ODataSwaggerDocsConfig.cs
@@ -8,6 +8,7 @@ using Swashbuckle.Application;
 using Swashbuckle.OData.Descriptions;
 using Swashbuckle.Swagger;
 using System.Xml.XPath;
+using System.Web.Http.Dispatcher;
 
 namespace Swashbuckle.OData
 {
@@ -169,15 +170,29 @@ namespace Swashbuckle.OData
         {
             return _swaggerDocsConfig.GetFieldValue<VersionInfoBuilder>("_versionInfoBuilder", true).Build();
         }
-
+        /// <summary>
+        /// Include the navigation properties (get related entities in the models)
+        /// </summary>
         public void IncludeNavigationProperties()
         {
             _includeNavigationProperties = true;
         }
 
+        /// <summary>
+        /// Enable Swagger built-in Cache
+        /// </summary>
         public void EnableSwaggerRequestCaching()
         {
             enableCache = true;
+        }
+
+        /// <summary>
+        /// Set a custom assembliesResolver to get the assemblies from where the types are going to be loaded
+        /// </summary>
+        /// <param name="assembliesResolver">custom assemblies resolver.</param>
+        public void SetAssembliesResolver(IAssembliesResolver assembliesResolver)
+        {
+            System.Web.OData.TypeHelper.SetAssembliesResolver(assembliesResolver);
         }
     }
 }


### PR DESCRIPTION
Unify way of loading assemblies for getting types.
Add assemblies resolver injection.
Move IAssembliesResolver property to the class where is being used.
Add test for assemblies resolver injection.
Update NewtonSoftJson version in Sample and Test projects.
Fix accesibility of methods and other minor changes