### PR TITLE
Updating bits to OData 7.2

### DIFF
--- a/Swashbuckle.OData.NuGetPackage/Swashbuckle.OData.NuGetPackage.nuproj
+++ b/Swashbuckle.OData.NuGetPackage/Swashbuckle.OData.NuGetPackage.nuproj
@@ -19,7 +19,7 @@
   <Import Project="$(NuProjPath)\NuProj.props" Condition="Exists('$(NuProjPath)\NuProj.props')" />
   <PropertyGroup Label="Configuration">
     <Id>Swashbuckle.OData</Id>
-    <Version>3.3.0</Version>
+    <Version>4.0.0-beta1</Version>
     <Title>Swashbuckle.OData</Title>
     <Authors>Richard Beauchamp and the Swashbuckle.OData contributors</Authors>
     <Owners>Richard Beauchamp</Owners>
@@ -28,9 +28,10 @@
     <ReleaseNotes>Added built-in cache support.</ReleaseNotes>
     <ProjectUrl>https://github.com/rbeauchamp/Swashbuckle.OData</ProjectUrl>
     <LicenseUrl>https://github.com/rbeauchamp/Swashbuckle.OData/blob/master/License.txt</LicenseUrl>
-    <Copyright>Copyright © 2015 - 2016 Richard Beauchamp and the Swashbuckle.OData contributors</Copyright>
+    <Copyright>Copyright © 2015 - 2017 Richard Beauchamp and the Swashbuckle.OData contributors</Copyright>
     <Tags>Swashbuckle Swagger SwaggerUI OData Documentation Discovery Help WebApi AspNet AspNetWebApi Docs WebHost IIS</Tags>
-    <GenerateSymbolPackage>false</GenerateSymbolPackage>
+    <GenerateSymbolPackage>true</GenerateSymbolPackage>
+    <EmbedSourceFiles>true</EmbedSourceFiles>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Swashbuckle.OData\Swashbuckle.OData.csproj" />

--- a/Swashbuckle.OData.Sample/Swashbuckle.OData.Sample.csproj
+++ b/Swashbuckle.OData.Sample/Swashbuckle.OData.Sample.csproj
@@ -55,44 +55,44 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Microsoft.Extensions.DependencyInjection, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.1.0.0\lib\netstandard1.1\Microsoft.Extensions.DependencyInjection.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.DependencyInjection, Version=1.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.1.1.1\lib\netstandard1.1\Microsoft.Extensions.DependencyInjection.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.1.0.0\lib\netstandard1.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=1.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.1.1.1\lib\netstandard1.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.OData.Core, Version=7.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.OData.Core.7.0.0\lib\portable-net45+win8+wpa81\Microsoft.OData.Core.dll</HintPath>
+    <Reference Include="Microsoft.OData.Core, Version=7.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.OData.Core.7.2.0\lib\portable-net45+win8+wpa81\Microsoft.OData.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.OData.Edm, Version=7.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.OData.Edm.7.0.0\lib\portable-net45+win8+wpa81\Microsoft.OData.Edm.dll</HintPath>
+    <Reference Include="Microsoft.OData.Edm, Version=7.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.OData.Edm.7.2.0\lib\portable-net45+win8+wpa81\Microsoft.OData.Edm.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Restier.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Restier.Core.1.0.0-beta\lib\net45\Microsoft.Restier.Core.dll</HintPath>
+    <Reference Include="Microsoft.Restier.Core, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\AdvancedREI.Restier.Core.1.0.0-beta2b\lib\net452\Microsoft.Restier.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Restier.Providers.EntityFramework, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Restier.Providers.EntityFramework.1.0.0-beta\lib\net45\Microsoft.Restier.Providers.EntityFramework.dll</HintPath>
+    <Reference Include="Microsoft.Restier.Providers.EntityFramework, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\AdvancedREI.Restier.Providers.EntityFramework.1.0.0-beta2b\lib\net452\Microsoft.Restier.Providers.EntityFramework.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Restier.Publishers.OData, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Restier.Publishers.OData.1.0.0-beta\lib\net45\Microsoft.Restier.Publishers.OData.dll</HintPath>
+    <Reference Include="Microsoft.Restier.Publishers.OData, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\AdvancedREI.Restier.Publishers.OData.1.0.0-beta2b\lib\net452\Microsoft.Restier.Publishers.OData.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Spatial, Version=7.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Spatial.7.0.0\lib\portable-net45+win8+wpa81\Microsoft.Spatial.dll</HintPath>
+    <Reference Include="Microsoft.Spatial, Version=7.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Spatial.7.2.0\lib\portable-net45+win8+wpa81\Microsoft.Spatial.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Swashbuckle.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=cd1bb07a5ac7c7bc, processorArchitecture=MSIL">
@@ -100,10 +100,21 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.IO.Compression" />
     <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.ValueTuple, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.3.1\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Web.Entity" />
@@ -135,7 +146,7 @@
     <Reference Include="System.Net.Http.WebRequest">
     </Reference>
     <Reference Include="WebActivatorEx, Version=2.0.0.0, Culture=neutral, PublicKeyToken=7b26dc2a43f6a0d4, processorArchitecture=MSIL">
-      <HintPath>..\packages\WebActivatorEx.2.1.0\lib\net40\WebActivatorEx.dll</HintPath>
+      <HintPath>..\packages\WebActivatorEx.2.2.0\lib\net40\WebActivatorEx.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/Swashbuckle.OData.Sample/Web.config
+++ b/Swashbuckle.OData.Sample/Web.config
@@ -17,7 +17,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" culture="neutral" publicKeyToken="30ad4fe6b2a6aeed" />
-        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Web.Http" publicKeyToken="31bf3856ad364e35" culture="neutral" />
@@ -29,15 +29,15 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.OData.Edm" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-7.2.0.0" newVersion="7.2.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.OData.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-7.2.0.0" newVersion="7.2.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Spatial" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.15.0.0" newVersion="6.15.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-7.2.0.0" newVersion="7.2.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Web.OData" publicKeyToken="31bf3856ad364e35" culture="neutral" />
@@ -46,6 +46,18 @@
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Restier.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.0.0.0" newVersion="1.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.1.1.0" newVersion="1.1.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.1.1.0" newVersion="1.1.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.1" newVersion="4.0.1.1" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Swashbuckle.OData.Sample/packages.config
+++ b/Swashbuckle.OData.Sample/packages.config
@@ -1,23 +1,57 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="AdvancedREI.Restier" version="1.0.0-beta2b" targetFramework="net452" />
+  <package id="AdvancedREI.Restier.Core" version="1.0.0-beta2b" targetFramework="net452" />
+  <package id="AdvancedREI.Restier.Providers.EntityFramework" version="1.0.0-beta2b" targetFramework="net452" />
+  <package id="AdvancedREI.Restier.Publishers.OData" version="1.0.0-beta2b" targetFramework="net452" />
   <package id="EntityFramework" version="6.1.3" targetFramework="net452" />
   <package id="Microsoft.AspNet.OData" version="6.0.0" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebApi" version="5.2.3" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebApi.Client" allowedVersions="(,6.0.0)" version="5.2.3" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebApi.Core" allowedVersions="(,6.0.0)" version="5.2.3" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebApi.WebHost" allowedVersions="(,6.0.0)" version="5.2.3" targetFramework="net452" />
-  <package id="Microsoft.Extensions.DependencyInjection" version="1.0.0" targetFramework="net452" />
-  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.0.0" targetFramework="net452" />
-  <package id="Microsoft.OData.Core" version="7.0.0" targetFramework="net452" />
-  <package id="Microsoft.OData.Edm" version="7.0.0" targetFramework="net452" />
-  <package id="Microsoft.Restier" version="1.0.0-beta" targetFramework="net452" />
-  <package id="Microsoft.Restier.Core" version="1.0.0-beta" targetFramework="net452" />
-  <package id="Microsoft.Restier.Providers.EntityFramework" version="1.0.0-beta" targetFramework="net452" />
-  <package id="Microsoft.Restier.Publishers.OData" version="1.0.0-beta" targetFramework="net452" />
-  <package id="Microsoft.Spatial" version="7.0.0" targetFramework="net452" />
+  <package id="Microsoft.Extensions.DependencyInjection" version="1.1.1" targetFramework="net452" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.1.1" targetFramework="net452" />
+  <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net452" />
+  <package id="Microsoft.OData.Core" version="7.2.0" targetFramework="net452" />
+  <package id="Microsoft.OData.Edm" version="7.2.0" targetFramework="net452" />
+  <package id="Microsoft.Spatial" version="7.2.0" targetFramework="net452" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net452" />
-  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net452" />
+  <package id="NETStandard.Library" version="1.6.1" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net452" />
   <package id="Swashbuckle" version="5.5.3" targetFramework="net452" />
   <package id="Swashbuckle.Core" version="5.5.3" targetFramework="net452" />
-  <package id="WebActivatorEx" version="2.1.0" targetFramework="net452" />
+  <package id="System.Collections" version="4.3.0" targetFramework="net452" />
+  <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net452" />
+  <package id="System.ComponentModel" version="4.3.0" targetFramework="net452" />
+  <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net452" />
+  <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="net452" />
+  <package id="System.Diagnostics.Tracing" version="4.3.0" targetFramework="net452" />
+  <package id="System.Globalization" version="4.3.0" targetFramework="net452" />
+  <package id="System.IO" version="4.3.0" targetFramework="net452" />
+  <package id="System.IO.Compression" version="4.3.0" targetFramework="net452" />
+  <package id="System.Linq" version="4.3.0" targetFramework="net452" />
+  <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net452" />
+  <package id="System.Net.Http" version="4.3.2" targetFramework="net452" />
+  <package id="System.Net.Primitives" version="4.3.0" targetFramework="net452" />
+  <package id="System.ObjectModel" version="4.3.0" targetFramework="net452" />
+  <package id="System.Reflection" version="4.3.0" targetFramework="net452" />
+  <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net452" />
+  <package id="System.Reflection.Primitives" version="4.3.0" targetFramework="net452" />
+  <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net452" />
+  <package id="System.Runtime" version="4.3.0" targetFramework="net452" />
+  <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net452" />
+  <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net452" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net452" />
+  <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net452" />
+  <package id="System.Text.Encoding" version="4.3.0" targetFramework="net452" />
+  <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net452" />
+  <package id="System.Text.RegularExpressions" version="4.3.0" targetFramework="net452" />
+  <package id="System.Threading" version="4.3.0" targetFramework="net452" />
+  <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net452" />
+  <package id="System.Threading.Timer" version="4.3.0" targetFramework="net452" />
+  <package id="System.ValueTuple" version="4.3.1" targetFramework="net452" />
+  <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net452" />
+  <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net452" />
+  <package id="WebActivatorEx" version="2.2.0" targetFramework="net452" />
 </packages>

--- a/Swashbuckle.OData.Tests/Fixtures/EnableQueryTests.cs
+++ b/Swashbuckle.OData.Tests/Fixtures/EnableQueryTests.cs
@@ -51,7 +51,7 @@ namespace Swashbuckle.OData.Tests
 
                 pathItem.get.parameters.Where(parameter => parameter.name.StartsWith("$")).Should().OnlyContain(parameter => parameter.required == false);
 
-                pathItem.get.parameters.Count(parameter => parameter.name.StartsWith("$")).Should().Be(7);
+                pathItem.get.parameters.Count(parameter => parameter.name.StartsWith("$")).Should().Be(8);
 
                 await ValidationUtils.ValidateSwaggerJson();
             }

--- a/Swashbuckle.OData.Tests/Fixtures/GetTests.cs
+++ b/Swashbuckle.OData.Tests/Fixtures/GetTests.cs
@@ -76,7 +76,7 @@ namespace Swashbuckle.OData.Tests
                 // Assert
                 PathItem pathItem;
                 swaggerDocument.paths.TryGetValue("/odata/Customers", out pathItem);
-                pathItem.get.parameters.Where(parameter => parameter.name.StartsWith("$")).Should().HaveCount(7);
+                pathItem.get.parameters.Where(parameter => parameter.name.StartsWith("$")).Should().HaveCount(8);
 
                 await ValidationUtils.ValidateSwaggerJson();
             }

--- a/Swashbuckle.OData.Tests/Swashbuckle.OData.Tests.csproj
+++ b/Swashbuckle.OData.Tests/Swashbuckle.OData.Tests.csproj
@@ -43,68 +43,68 @@
       <HintPath>..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.SqlServer.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="FluentAssertions, Version=4.14.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <HintPath>..\packages\FluentAssertions.4.14.0\lib\net45\FluentAssertions.dll</HintPath>
+    <Reference Include="FluentAssertions, Version=4.19.2.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\packages\FluentAssertions.4.19.2\lib\net45\FluentAssertions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="FluentAssertions.Core, Version=4.14.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <HintPath>..\packages\FluentAssertions.4.14.0\lib\net45\FluentAssertions.Core.dll</HintPath>
+    <Reference Include="FluentAssertions.Core, Version=4.19.2.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\packages\FluentAssertions.4.19.2\lib\net45\FluentAssertions.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Extensions.DependencyInjection, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.1.0.0\lib\netstandard1.1\Microsoft.Extensions.DependencyInjection.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.DependencyInjection, Version=1.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.1.1.1\lib\netstandard1.1\Microsoft.Extensions.DependencyInjection.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.1.0.0\lib\netstandard1.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=1.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.1.1.1\lib\netstandard1.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.OData.Core, Version=7.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.OData.Core.7.0.0\lib\portable-net45+win8+wpa81\Microsoft.OData.Core.dll</HintPath>
+    <Reference Include="Microsoft.OData.Core, Version=7.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.OData.Core.7.2.0\lib\portable-net45+win8+wpa81\Microsoft.OData.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.OData.Edm, Version=7.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.OData.Edm.7.0.0\lib\portable-net45+win8+wpa81\Microsoft.OData.Edm.dll</HintPath>
+    <Reference Include="Microsoft.OData.Edm, Version=7.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.OData.Edm.7.2.0\lib\portable-net45+win8+wpa81\Microsoft.OData.Edm.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Owin, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Owin.3.0.1\lib\net45\Microsoft.Owin.dll</HintPath>
+    <Reference Include="Microsoft.Owin, Version=3.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.3.1.0\lib\net45\Microsoft.Owin.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Owin.Host.HttpListener, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Owin.Host.HttpListener.3.0.1\lib\net45\Microsoft.Owin.Host.HttpListener.dll</HintPath>
+    <Reference Include="Microsoft.Owin.Host.HttpListener, Version=3.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.Host.HttpListener.3.1.0\lib\net45\Microsoft.Owin.Host.HttpListener.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Owin.Hosting, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Owin.Hosting.3.0.1\lib\net45\Microsoft.Owin.Hosting.dll</HintPath>
+    <Reference Include="Microsoft.Owin.Hosting, Version=3.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.Hosting.3.1.0\lib\net45\Microsoft.Owin.Hosting.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Restier.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Restier.Core.1.0.0-beta\lib\net45\Microsoft.Restier.Core.dll</HintPath>
+    <Reference Include="Microsoft.Restier.Core, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\AdvancedREI.Restier.Core.1.0.0-beta2b\lib\net452\Microsoft.Restier.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Restier.Providers.EntityFramework, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Restier.Providers.EntityFramework.1.0.0-beta\lib\net45\Microsoft.Restier.Providers.EntityFramework.dll</HintPath>
+    <Reference Include="Microsoft.Restier.Providers.EntityFramework, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\AdvancedREI.Restier.Providers.EntityFramework.1.0.0-beta2b\lib\net452\Microsoft.Restier.Providers.EntityFramework.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Restier.Publishers.OData, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Restier.Publishers.OData.1.0.0-beta\lib\net45\Microsoft.Restier.Publishers.OData.dll</HintPath>
+    <Reference Include="Microsoft.Restier.Publishers.OData, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\AdvancedREI.Restier.Publishers.OData.1.0.0-beta2b\lib\net452\Microsoft.Restier.Publishers.OData.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Spatial, Version=7.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Spatial.7.0.0\lib\portable-net45+win8+wpa81\Microsoft.Spatial.dll</HintPath>
+    <Reference Include="Microsoft.Spatial, Version=7.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Spatial.7.2.0\lib\portable-net45+win8+wpa81\Microsoft.Spatial.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json.Schema, Version=1.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.Schema.1.0.11\lib\net45\Newtonsoft.Json.Schema.dll</HintPath>
+    <Reference Include="Newtonsoft.Json.Schema, Version=2.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.Schema.2.0.12\lib\net45\Newtonsoft.Json.Schema.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.6.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.6.1\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
@@ -116,15 +116,26 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
+    <Reference Include="System.IO.Compression" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Net.Http.WebRequest" />
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.ValueTuple, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.3.1\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
       <Private>True</Private>
@@ -200,12 +211,12 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
-    <None Include="schema-draft-v4.json">
+    <Content Include="schema-draft-v4.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="swagger-2.0-schema.json">
+    </Content>
+    <Content Include="swagger-2.0-schema.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
+    </Content>
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>
@@ -220,7 +231,9 @@
       <Name>Swashbuckle.OData</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Swashbuckle.OData.Tests/Swashbuckle.OData.Tests.csproj
+++ b/Swashbuckle.OData.Tests/Swashbuckle.OData.Tests.csproj
@@ -213,7 +213,7 @@
     <None Include="app.config">
       <SubType>Designer</SubType>
     </None>
-    <Contentontent Include="schema-draft-v4.json">
+    <Content Include="schema-draft-v4.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="swagger-2.0-schema.json">

--- a/Swashbuckle.OData.Tests/ValidationUtils.cs
+++ b/Swashbuckle.OData.Tests/ValidationUtils.cs
@@ -8,6 +8,7 @@ using FluentAssertions;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Schema;
 using Swashbuckle.Swagger;
+using System.Reflection;
 
 namespace Swashbuckle.OData.Tests
 {
@@ -55,11 +56,13 @@ namespace Swashbuckle.OData.Tests
         private static async Task IsValidAgainstJsonSchemaAsync(HttpResponseMessage response)
         {
             var swaggerJson = await response.Content.ReadAsStringAsync();
+            var dir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+
 
             var resolver = new JSchemaPreloadedResolver();
-            resolver.Add(new Uri("http://json-schema.org/draft-04/schema"), File.ReadAllText(@"schema-draft-v4.json"));
+            resolver.Add(new Uri("http://json-schema.org/draft-04/schema"), File.ReadAllText(Path.Combine(dir, @"../../schema-draft-v4.json")));
 
-            var swaggerSchema = File.ReadAllText(@"swagger-2.0-schema.json");
+            var swaggerSchema = File.ReadAllText(Path.Combine(dir, @"../../swagger-2.0-schema.json"));
             var schema = JSchema.Parse(swaggerSchema, resolver);
 
             var swaggerJObject = JObject.Parse(swaggerJson);

--- a/Swashbuckle.OData.Tests/app.config
+++ b/Swashbuckle.OData.Tests/app.config
@@ -16,7 +16,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
@@ -24,19 +24,19 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.0.1.0" newVersion="3.0.1.0" />
+        <bindingRedirect oldVersion="0.0.0.0-3.1.0.0" newVersion="3.1.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.OData.Edm" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-7.2.0.0" newVersion="7.2.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.OData.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-7.2.0.0" newVersion="7.2.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Spatial" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.15.0.0" newVersion="6.15.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-7.2.0.0" newVersion="7.2.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Web.OData" publicKeyToken="31bf3856ad364e35" culture="neutral" />
@@ -45,6 +45,18 @@
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Restier.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.0.0.0" newVersion="1.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.1.1.0" newVersion="1.1.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.1" newVersion="4.0.1.1" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.1.1.0" newVersion="1.1.1.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Swashbuckle.OData.Tests/packages.config
+++ b/Swashbuckle.OData.Tests/packages.config
@@ -1,30 +1,70 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="AdvancedREI.Restier" version="1.0.0-beta2b" targetFramework="net452" />
+  <package id="AdvancedREI.Restier.Core" version="1.0.0-beta2b" targetFramework="net452" />
+  <package id="AdvancedREI.Restier.Providers.EntityFramework" version="1.0.0-beta2b" targetFramework="net452" />
+  <package id="AdvancedREI.Restier.Publishers.OData" version="1.0.0-beta2b" targetFramework="net452" />
   <package id="coveralls.io" version="1.3.4" targetFramework="net452" />
   <package id="EntityFramework" version="6.1.3" targetFramework="net452" />
-  <package id="FluentAssertions" version="4.14.0" targetFramework="net452" />
+  <package id="FluentAssertions" version="4.19.2" targetFramework="net452" />
   <package id="Microsoft.AspNet.OData" version="6.0.0" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebApi.Client" allowedVersions="(,6.0.0)" version="5.2.3" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebApi.Core" allowedVersions="(,6.0.0)" version="5.2.3" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebApi.Owin" version="5.2.3" targetFramework="net452" />
-  <package id="Microsoft.Extensions.DependencyInjection" version="1.0.0" targetFramework="net452" />
-  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.0.0" targetFramework="net452" />
-  <package id="Microsoft.OData.Core" version="7.0.0" targetFramework="net452" />
-  <package id="Microsoft.OData.Edm" version="7.0.0" targetFramework="net452" />
-  <package id="Microsoft.Owin" version="3.0.1" targetFramework="net452" />
-  <package id="Microsoft.Owin.Host.HttpListener" version="3.0.1" targetFramework="net452" />
-  <package id="Microsoft.Owin.Hosting" version="3.0.1" targetFramework="net452" />
-  <package id="Microsoft.Restier" version="1.0.0-beta" targetFramework="net452" />
-  <package id="Microsoft.Restier.Core" version="1.0.0-beta" targetFramework="net452" />
-  <package id="Microsoft.Restier.Providers.EntityFramework" version="1.0.0-beta" targetFramework="net452" />
-  <package id="Microsoft.Restier.Publishers.OData" version="1.0.0-beta" targetFramework="net452" />
-  <package id="Microsoft.Spatial" version="7.0.0" targetFramework="net452" />
-  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net452" />
-  <package id="Newtonsoft.Json.Schema" version="1.0.11" targetFramework="net452" />
-  <package id="NUnit" version="2.6.4" targetFramework="net452" />
-  <package id="NUnit.Runners" version="2.6.4" targetFramework="net452" />
+  <package id="Microsoft.Extensions.DependencyInjection" version="1.1.1" targetFramework="net452" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.1.1" targetFramework="net452" />
+  <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net452" />
+  <package id="Microsoft.OData.Core" version="7.2.0" targetFramework="net452" />
+  <package id="Microsoft.OData.Edm" version="7.2.0" targetFramework="net452" />
+  <package id="Microsoft.Owin" version="3.1.0" targetFramework="net452" />
+  <package id="Microsoft.Owin.Host.HttpListener" version="3.1.0" targetFramework="net452" />
+  <package id="Microsoft.Owin.Hosting" version="3.1.0" targetFramework="net452" />
+  <package id="Microsoft.Spatial" version="7.2.0" targetFramework="net452" />
+  <package id="NETStandard.Library" version="1.6.1" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net452" />
+  <package id="Newtonsoft.Json.Schema" version="2.0.12" targetFramework="net452" />
+  <package id="NUnit" version="3.6.1" targetFramework="net452" />
+  <package id="NUnit.ConsoleRunner" version="3.6.1" targetFramework="net452" />
+  <package id="NUnit.Extension.NUnitProjectLoader" version="3.5.0" targetFramework="net452" />
+  <package id="NUnit.Extension.NUnitV2Driver" version="3.6.0" targetFramework="net452" />
+  <package id="NUnit.Extension.NUnitV2ResultWriter" version="3.5.0" targetFramework="net452" />
+  <package id="NUnit.Extension.TeamCityEventListener" version="1.0.2" targetFramework="net452" />
+  <package id="NUnit.Extension.VSProjectLoader" version="3.5.0" targetFramework="net452" />
+  <package id="NUnit.Runners" version="3.6.1" targetFramework="net452" />
   <package id="OpenCover" version="4.6.519" targetFramework="net452" />
   <package id="Owin" version="1.0" targetFramework="net452" />
-  <package id="ReportGenerator" version="2.4.3.0" targetFramework="net452" />
+  <package id="ReportGenerator" version="2.5.8" targetFramework="net452" />
   <package id="Swashbuckle.Core" allowedVersions="(5.5.2,)" version="5.5.3" targetFramework="net452" />
+  <package id="System.Collections" version="4.3.0" targetFramework="net452" />
+  <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net452" />
+  <package id="System.ComponentModel" version="4.3.0" targetFramework="net452" />
+  <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net452" />
+  <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="net452" />
+  <package id="System.Diagnostics.Tracing" version="4.3.0" targetFramework="net452" />
+  <package id="System.Globalization" version="4.3.0" targetFramework="net452" />
+  <package id="System.IO" version="4.3.0" targetFramework="net452" />
+  <package id="System.IO.Compression" version="4.3.0" targetFramework="net452" />
+  <package id="System.Linq" version="4.3.0" targetFramework="net452" />
+  <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net452" />
+  <package id="System.Net.Http" version="4.3.2" targetFramework="net452" />
+  <package id="System.Net.Primitives" version="4.3.0" targetFramework="net452" />
+  <package id="System.ObjectModel" version="4.3.0" targetFramework="net452" />
+  <package id="System.Reflection" version="4.3.0" targetFramework="net452" />
+  <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net452" />
+  <package id="System.Reflection.Primitives" version="4.3.0" targetFramework="net452" />
+  <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net452" />
+  <package id="System.Runtime" version="4.3.0" targetFramework="net452" />
+  <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net452" />
+  <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net452" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net452" />
+  <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net452" />
+  <package id="System.Text.Encoding" version="4.3.0" targetFramework="net452" />
+  <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net452" />
+  <package id="System.Text.RegularExpressions" version="4.3.0" targetFramework="net452" />
+  <package id="System.Threading" version="4.3.0" targetFramework="net452" />
+  <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net452" />
+  <package id="System.Threading.Timer" version="4.3.0" targetFramework="net452" />
+  <package id="System.ValueTuple" version="4.3.1" targetFramework="net452" />
+  <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net452" />
+  <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net452" />
 </packages>

--- a/Swashbuckle.OData/Descriptions/ODataSwaggerUtilities.cs
+++ b/Swashbuckle.OData/Descriptions/ODataSwaggerUtilities.cs
@@ -141,6 +141,7 @@ namespace Swashbuckle.OData.Descriptions
                 .Parameter("$expand", "query", "Expands related entities inline.", "string", false)
                 .Parameter("$filter", "query", "Filters the results, based on a Boolean condition.", "string", false)
                 .Parameter("$select", "query", "Selects which properties to include in the response.", "string", false)
+                .Parameter("$apply", "query", "Aggregates the results according to one or more transformations.", "string", false)
                 .Parameter("$orderby", "query", "Sorts the results.", "string", false)
                 .Parameter("$top", "query", "Returns only the first n results.", "integer", false, "int32")
                 .Parameter("$skip", "query", "Skips the first n results.", "integer", false, "int32")

--- a/Swashbuckle.OData/Descriptions/SwaggerRouteStrategy.cs
+++ b/Swashbuckle.OData/Descriptions/SwaggerRouteStrategy.cs
@@ -115,7 +115,8 @@ namespace Swashbuckle.OData.Descriptions
             if (actionDescriptor.ControllerDescriptor.ControllerName == "Restier")
             {
                 var odataPath = request.ODataProperties().Path;
-                var entitySetName = odataPath.NavigationSource.Name;
+                //RWM: For unbounded functions, the NavigationSource will be null.
+                var entitySetName = odataPath.NavigationSource?.Name ?? "(root)";
                 Type returnType = null;
                 if (ReturnsValue(request))
                 {

--- a/Swashbuckle.OData/Swashbuckle.OData.csproj
+++ b/Swashbuckle.OData/Swashbuckle.OData.csproj
@@ -25,10 +25,10 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;CONTRACTS_FULL</DefineConstants>
+    <DefineConstants>TRACE;DEBUG</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <CodeContractsEnableRuntimeChecking>True</CodeContractsEnableRuntimeChecking>
+    <CodeContractsEnableRuntimeChecking>False</CodeContractsEnableRuntimeChecking>
     <CodeContractsRuntimeOnlyPublicSurface>False</CodeContractsRuntimeOnlyPublicSurface>
     <CodeContractsRuntimeThrowOnFailure>True</CodeContractsRuntimeThrowOnFailure>
     <CodeContractsRuntimeCallSiteRequires>False</CodeContractsRuntimeCallSiteRequires>
@@ -132,42 +132,49 @@
     <AssemblyOriginatorKeyFile>Swashbuckle.Odata.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Extensions.DependencyInjection, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.1.0.0\lib\netstandard1.1\Microsoft.Extensions.DependencyInjection.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.DependencyInjection, Version=1.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.1.1.1\lib\netstandard1.1\Microsoft.Extensions.DependencyInjection.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.1.0.0\lib\netstandard1.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=1.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.1.1.1\lib\netstandard1.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.OData.Core, Version=7.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.OData.Core.7.0.0\lib\portable-net45+win8+wpa81\Microsoft.OData.Core.dll</HintPath>
+    <Reference Include="Microsoft.OData.Core, Version=7.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.OData.Core.7.2.0\lib\portable-net45+win8+wpa81\Microsoft.OData.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.OData.Edm, Version=7.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.OData.Edm.7.0.0\lib\portable-net45+win8+wpa81\Microsoft.OData.Edm.dll</HintPath>
+    <Reference Include="Microsoft.OData.Edm, Version=7.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.OData.Edm.7.2.0\lib\portable-net45+win8+wpa81\Microsoft.OData.Edm.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Spatial, Version=7.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Spatial.7.0.0\lib\portable-net45+win8+wpa81\Microsoft.Spatial.dll</HintPath>
+    <Reference Include="Microsoft.Spatial, Version=7.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Spatial.7.2.0\lib\portable-net45+win8+wpa81\Microsoft.Spatial.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Swashbuckle.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=cd1bb07a5ac7c7bc, processorArchitecture=MSIL">
-      <HintPath>..\packages\Swashbuckle.Core.5.5.2\lib\net40\Swashbuckle.Core.dll</HintPath>
+      <HintPath>..\packages\Swashbuckle.Core.5.5.3\lib\net40\Swashbuckle.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Core" />
+    <Reference Include="System.IO.Compression" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Net.Http.WebRequest" />
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Web" />
@@ -180,6 +187,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.XML" />
+    <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CollectionExtentions.cs" />

--- a/Swashbuckle.OData/app.config
+++ b/Swashbuckle.OData/app.config
@@ -8,7 +8,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
@@ -16,15 +16,23 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.OData.Edm" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.15.0.0" newVersion="6.15.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-7.2.0.0" newVersion="7.2.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.OData.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.15.0.0" newVersion="6.15.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-7.2.0.0" newVersion="7.2.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Spatial" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.15.0.0" newVersion="6.15.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-7.2.0.0" newVersion="7.2.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.1.1.0" newVersion="1.1.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.1.1.0" newVersion="1.1.1.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Swashbuckle.OData/packages.config
+++ b/Swashbuckle.OData/packages.config
@@ -3,11 +3,44 @@
   <package id="Microsoft.AspNet.OData" version="6.0.0" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebApi.Client" allowedVersions="(,6.0.0)" version="5.2.3" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebApi.Core" allowedVersions="(,6.0.0)" version="5.2.3" targetFramework="net452" />
-  <package id="Microsoft.Extensions.DependencyInjection" version="1.0.0" targetFramework="net452" />
-  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.0.0" targetFramework="net452" />
-  <package id="Microsoft.OData.Core" version="7.0.0" targetFramework="net452" />
-  <package id="Microsoft.OData.Edm" version="7.0.0" targetFramework="net452" />
-  <package id="Microsoft.Spatial" version="7.0.0" targetFramework="net452" />
-  <package id="Newtonsoft.Json" allowedVersions="[6.0.4,)" version="6.0.4" targetFramework="net452" />
-  <package id="Swashbuckle.Core" allowedVersions="[5.5.2,6.0.0)" version="5.5.2" targetFramework="net452" />
+  <package id="Microsoft.Extensions.DependencyInjection" version="1.1.1" targetFramework="net452" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.1.1" targetFramework="net452" />
+  <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net452" />
+  <package id="Microsoft.OData.Core" version="7.2.0" targetFramework="net452" />
+  <package id="Microsoft.OData.Edm" version="7.2.0" targetFramework="net452" />
+  <package id="Microsoft.Spatial" version="7.2.0" targetFramework="net452" />
+  <package id="NETStandard.Library" version="1.6.1" targetFramework="net452" />
+  <package id="Newtonsoft.Json" allowedVersions="[6.0.4,)" version="10.0.2" targetFramework="net452" />
+  <package id="Swashbuckle.Core" allowedVersions="[5.5.2,6.0.0)" version="5.5.3" targetFramework="net452" />
+  <package id="System.Collections" version="4.3.0" targetFramework="net452" />
+  <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net452" />
+  <package id="System.ComponentModel" version="4.3.0" targetFramework="net452" />
+  <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net452" />
+  <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="net452" />
+  <package id="System.Diagnostics.Tracing" version="4.3.0" targetFramework="net452" />
+  <package id="System.Globalization" version="4.3.0" targetFramework="net452" />
+  <package id="System.IO" version="4.3.0" targetFramework="net452" />
+  <package id="System.IO.Compression" version="4.3.0" targetFramework="net452" />
+  <package id="System.Linq" version="4.3.0" targetFramework="net452" />
+  <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net452" />
+  <package id="System.Net.Http" version="4.3.2" targetFramework="net452" />
+  <package id="System.Net.Primitives" version="4.3.0" targetFramework="net452" />
+  <package id="System.ObjectModel" version="4.3.0" targetFramework="net452" />
+  <package id="System.Reflection" version="4.3.0" targetFramework="net452" />
+  <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net452" />
+  <package id="System.Reflection.Primitives" version="4.3.0" targetFramework="net452" />
+  <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net452" />
+  <package id="System.Runtime" version="4.3.0" targetFramework="net452" />
+  <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net452" />
+  <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net452" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net452" />
+  <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net452" />
+  <package id="System.Text.Encoding" version="4.3.0" targetFramework="net452" />
+  <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net452" />
+  <package id="System.Text.RegularExpressions" version="4.3.0" targetFramework="net452" />
+  <package id="System.Threading" version="4.3.0" targetFramework="net452" />
+  <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net452" />
+  <package id="System.Threading.Timer" version="4.3.0" targetFramework="net452" />
+  <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net452" />
+  <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net452" />
 </packages>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 3.3.0.{build}
+version: 4.0.0.{build}
 
 before_build:
 - cmd: nuget restore
@@ -13,7 +13,7 @@ environment:
        secure: EFTW/YldlkfUPVuAZTbv09gYi8MtEbZ6WZ6AU23f5Bg9BuCPN8wMAZxvOzycWGvK
 
 after_test: 
-- packages\OpenCover.4.6.519\tools\OpenCover.Console.exe -register:user -filter:"+[Swashbuckle.OData]* -[Swashbuckle.OData]System.*" -target:"packages\NUnit.Runners.2.6.4\tools\nunit-console-x86.exe" -targetargs:"/noshadow /domain:single Swashbuckle.OData.Tests\bin\Debug\Swashbuckle.OData.Tests.dll" -output:coverage.xml
+- packages\OpenCover.4.6.519\tools\OpenCover.Console.exe -register:user -filter:"+[Swashbuckle.OData]* -[Swashbuckle.OData]System.*" -target:"packages\NUnit.ConsoleRunner.3.6.1\tools\nunit3-console.exe" -targetargs:"/noshadow /domain:single Swashbuckle.OData.Tests\bin\Debug\Swashbuckle.OData.Tests.dll" -output:coverage.xml
 - packages\coveralls.io.1.3.4\tools\coveralls.net.exe --opencover coverage.xml
 
 deploy:

--- a/coverage.bat
+++ b/coverage.bat
@@ -1,8 +1,8 @@
 set OpenCoverVersion=4.6.519
-set ReportGeneratorVersion=2.4.3.0
-set NUnitRunnersVersion=2.6.4
+set ReportGeneratorVersion=2.5.8
+set NUnitRunnersVersion=3.6.1
 
-.\packages\OpenCover.%OpenCoverVersion%\tools\OpenCover.Console.exe -register:user "-filter:+[Swashbuckle.OData]* -[Swashbuckle.OData]System.*" "-target:.\packages\NUnit.Runners.%NUnitRunnersVersion%\tools\nunit-console-x86.exe" "-targetargs:/noshadow .\Swashbuckle.OData.Tests\bin\Debug\Swashbuckle.OData.Tests.dll"
+.\packages\OpenCover.%OpenCoverVersion%\tools\OpenCover.Console.exe -register:user "-filter:+[Swashbuckle.OData]* -[Swashbuckle.OData]System.*" "-target:.\packages\NUnit.ConsoleRunner.%NUnitRunnersVersion%\tools\nunit3-console.exe" "-targetargs:/noshadow .\Swashbuckle.OData.Tests\bin\Debug\Swashbuckle.OData.Tests.dll"
 
 .\packages\ReportGenerator.%ReportGeneratorVersion%\tools\ReportGenerator.exe "-reports:results.xml" "-targetdir:.\coverage"
 


### PR DESCRIPTION
- Upgrade everything to the latest NuGet packages, (Including OData 7.2, which supports .NET Standard).
- Fix bug in Restier controllers where it SwaggerRouteStrategy did not account for unbounded functions.
- Temporarily replace Microsoft's Restier NuGets with AdvancedREI's newer fork (tests only).
- Fix unit tests that were relying on relative mapping instead of using absolute locations.
- Temporarily disables runtime code contracts (causing issues in IIS10).
- Incremented the major build on the NuGet package (because OData 7.2 may have breaking changes).
- Added support for the $apply entity set option in OData v4 (#147)