### PR TITLE
Several enhancements to Swashbuckle.OData 

### DIFF
--- a/Swashbuckle.OData.Tests/Fixtures/GlobalEnableQueryTests.cs
+++ b/Swashbuckle.OData.Tests/Fixtures/GlobalEnableQueryTests.cs
@@ -1,0 +1,115 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Web.Http;
+using System.Web.OData;
+using System.Web.OData.Builder;
+using System.Web.OData.Extensions;
+using System.Web.OData.Query;
+using FluentAssertions;
+using Microsoft.OData.Edm;
+using Microsoft.Owin.Hosting;
+using NUnit.Framework;
+using Owin;
+using Swashbuckle.Swagger;
+using System.Web.Http.Description;
+
+namespace Swashbuckle.OData.Tests
+{
+    /// <summary>
+    /// Tests the scenario where developer adds EnableQuery globally.
+    /// </summary>
+    [TestFixture]
+    public class GlobalEnableQueryTests
+    {
+        [Test]
+        public async Task It_Finds_Global_Enable_Query_AndReturn_Swagger_Doc_With_OData_Standard_Parameters()
+        {
+            using (WebApp.Start(HttpClientUtils.BaseAddress, appBuilder => Configuration(appBuilder, typeof(Customer1Controller))))
+            {
+                // Arrange
+                var httpClient = HttpClientUtils.GetHttpClient(HttpClientUtils.BaseAddress);
+
+                // Verify that the OData route in the test controller is valid
+                var customers = await httpClient.GetJsonAsync<ODataResponse<List<Customer1>>>("/odata/Customer1/Default.GetSomeCustomers()");
+                customers.Should().NotBeNull();
+
+                var number = await httpClient.GetJsonAsync<ODataResponse<int>>("/odata/Customer1/Default.GetSomeNumber()");
+                customers.Should().NotBeNull();
+
+                // Act
+                var swaggerDocument = await httpClient.GetJsonAsync<SwaggerDocument>("swagger/docs/v1");
+
+                // Assert
+                PathItem getCustomersPathItem;
+                swaggerDocument.paths.TryGetValue("/odata/Customer1/Default.GetSomeCustomers()", out getCustomersPathItem);
+                getCustomersPathItem.Should().NotBeNull();
+                getCustomersPathItem.get.Should().NotBeNull();
+                Assert.IsTrue(getCustomersPathItem.get.parameters.Any(p => p.name == "$filter"));
+
+                PathItem getSomeNumber;
+                swaggerDocument.paths.TryGetValue("/odata/Customer1/Default.GetSomeNumber()", out getSomeNumber);
+                getSomeNumber.Should().NotBeNull();
+                getSomeNumber.get.Should().NotBeNull();
+                Assert.IsTrue(getSomeNumber.get.parameters == null);
+
+                await ValidationUtils.ValidateSwaggerJson();
+            }
+        }
+
+        private void Configuration(IAppBuilder appBuilder, Type targetController)
+        {
+            var config = appBuilder.GetStandardHttpConfig(targetController);
+
+            config.MapODataServiceRoute("ODataRoute", "odata", GetEdmModel());
+
+            config.AddODataQueryFilter();
+            config.Filters.Add(new EnableQueryAttribute { });
+
+            config.EnsureInitialized();
+        }
+
+        private IEdmModel GetEdmModel()
+        {
+            ODataModelBuilder builder = new ODataConventionModelBuilder();
+
+            var customers = builder.EntitySet<Customer1>("Customer1");
+
+            var getSomeCustomers = customers.EntityType.Collection.Function("GetSomeCustomers");
+            getSomeCustomers.ReturnsCollectionFromEntitySet<Customer1>("Customer1");
+
+            var getSomeNumber = customers.EntityType.Collection.Function("GetSomeNumber");
+            getSomeNumber.Returns<int>();
+
+            return builder.GetEdmModel();
+        }
+    }
+
+    public class Customer1
+    {
+        [Key]
+        public int Id { get; set; }
+
+        public string Name { get; set; }
+    }
+
+    public class Customer1Controller : ODataController
+    {
+        [HttpGet]
+        [ResponseType(typeof(List<Customer1>))]
+        public IHttpActionResult GetSomeCustomers()
+        {
+            return Ok(Enumerable.Empty<Customer1>());
+        }
+
+        [HttpGet]
+        [ResponseType(typeof(int))]
+        public IHttpActionResult GetSomeNumber()
+        {
+            return Ok(0);
+        }
+    }
+}

--- a/Swashbuckle.OData.Tests/Swashbuckle.OData.Tests.csproj
+++ b/Swashbuckle.OData.Tests/Swashbuckle.OData.Tests.csproj
@@ -159,6 +159,7 @@
     <Compile Include="Containment\ODataModels.cs" />
     <Compile Include="Containment\Program.cs" />
     <Compile Include="ContentType.cs" />
+    <Compile Include="Fixtures\GlobalEnableQueryTests.cs" />
     <Compile Include="Fixtures\SummaryTests.cs" />
     <Compile Include="Fixtures\ParameterTests\DecimalParameterAndResponseTests.cs" />
     <Compile Include="Fixtures\ModelSharedBetweenODataAndWebApiTests.cs" />

--- a/Swashbuckle.OData.Tests/Swashbuckle.OData.Tests.csproj
+++ b/Swashbuckle.OData.Tests/Swashbuckle.OData.Tests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\NUnit3TestAdapter.3.8.0\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\packages\NUnit3TestAdapter.3.8.0\build\net35\NUnit3TestAdapter.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -103,9 +104,8 @@
       <HintPath>..\packages\Newtonsoft.Json.Schema.2.0.12\lib\net45\Newtonsoft.Json.Schema.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework, Version=3.6.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.6.1\lib\net45\nunit.framework.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="nunit.framework, Version=3.7.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.7.1\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
       <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
@@ -237,6 +237,12 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\NUnit3TestAdapter.3.8.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit3TestAdapter.3.8.0\build\net35\NUnit3TestAdapter.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Swashbuckle.OData.Tests/packages.config
+++ b/Swashbuckle.OData.Tests/packages.config
@@ -23,14 +23,15 @@
   <package id="NETStandard.Library" version="1.6.1" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net452" />
   <package id="Newtonsoft.Json.Schema" version="2.0.12" targetFramework="net452" />
-  <package id="NUnit" version="3.6.1" targetFramework="net452" />
-  <package id="NUnit.ConsoleRunner" version="3.6.1" targetFramework="net452" />
-  <package id="NUnit.Extension.NUnitProjectLoader" version="3.5.0" targetFramework="net452" />
-  <package id="NUnit.Extension.NUnitV2Driver" version="3.6.0" targetFramework="net452" />
-  <package id="NUnit.Extension.NUnitV2ResultWriter" version="3.5.0" targetFramework="net452" />
+  <package id="NUnit" version="3.7.1" targetFramework="net452" />
+  <package id="NUnit.ConsoleRunner" version="3.7.0" targetFramework="net452" />
+  <package id="NUnit.Extension.NUnitProjectLoader" version="3.6.0" targetFramework="net452" />
+  <package id="NUnit.Extension.NUnitV2Driver" version="3.7.0" targetFramework="net452" />
+  <package id="NUnit.Extension.NUnitV2ResultWriter" version="3.6.0" targetFramework="net452" />
   <package id="NUnit.Extension.TeamCityEventListener" version="1.0.2" targetFramework="net452" />
-  <package id="NUnit.Extension.VSProjectLoader" version="3.5.0" targetFramework="net452" />
-  <package id="NUnit.Runners" version="3.6.1" targetFramework="net452" />
+  <package id="NUnit.Extension.VSProjectLoader" version="3.6.0" targetFramework="net452" />
+  <package id="NUnit.Runners" version="3.7.0" targetFramework="net452" />
+  <package id="NUnit3TestAdapter" version="3.8.0" targetFramework="net452" />
   <package id="OpenCover" version="4.6.519" targetFramework="net452" />
   <package id="Owin" version="1.0" targetFramework="net452" />
   <package id="ReportGenerator" version="2.5.8" targetFramework="net452" />

--- a/Swashbuckle.OData/Descriptions/MapToODataActionParameter.cs
+++ b/Swashbuckle.OData/Descriptions/MapToODataActionParameter.cs
@@ -16,7 +16,8 @@ namespace Swashbuckle.OData.Descriptions
             if (swaggerParameter.@in == "body" && swaggerParameter.schema != null && swaggerParameter.schema.type == "object")
             {
                 var odataActionParametersDescriptor = actionDescriptor.GetParameters().SingleOrDefault(descriptor => descriptor.ParameterType == typeof (ODataActionParameters));
-                Contract.Assume(odataActionParametersDescriptor != null);
+                if (odataActionParametersDescriptor == null)
+                    return null;
                 return new ODataActionParameterDescriptor(odataActionParametersDescriptor.ParameterName, typeof(ODataActionParameters), !required.Value, swaggerParameter.schema, odataActionParametersDescriptor)
                 {
                     Configuration = actionDescriptor.ControllerDescriptor.Configuration,

--- a/Swashbuckle.OData/Descriptions/TypeHelper.cs
+++ b/Swashbuckle.OData/Descriptions/TypeHelper.cs
@@ -41,8 +41,8 @@ namespace System.Web.OData
 
         internal static bool IsCollection(this Type type)
         {
-            Contract.Requires(type != null);
-
+            if (type == null)
+                return false;
             Type elementType;
             return type.IsCollection(out elementType);
         }

--- a/Swashbuckle.OData/EnableQueryFilter.cs
+++ b/Swashbuckle.OData/EnableQueryFilter.cs
@@ -41,17 +41,10 @@ namespace Swashbuckle.OData
             var httpActionDescriptor = apiDescription.ActionDescriptor;
             Contract.Assume(httpActionDescriptor != null);
             return httpActionDescriptor.GetCustomAttributes<EnableQueryAttribute>().Any() || 
-                (ReturnTypeIsCollectionType(apiDescription) && httpActionDescriptor.GetFilterPipeline()
+                (ReturnsCollection(apiDescription) && httpActionDescriptor.GetFilterPipeline()
                                                                                         .Select(f => f.Instance)
                                                                                         .OfType<ActionFilterAttribute>()
                                                                                         .Any(f => f.TypeId is Type && typeof(EnableQueryAttribute).IsAssignableFrom((Type)f.TypeId)));
-        }
-
-        private static bool ReturnTypeIsCollectionType(ApiDescription apiDescription)
-        {
-            var httpActionDescriptor = apiDescription.ActionDescriptor;
-            Contract.Assume(httpActionDescriptor != null);
-            return typeof(SingleResult).IsAssignableFrom(httpActionDescriptor.ReturnType) || (typeof(IEnumerable).IsAssignableFrom(httpActionDescriptor.ReturnType) && httpActionDescriptor.ReturnType != typeof(string)); 
         }
 
         private static bool ReturnsCollection(ApiDescription apiDescription)

--- a/Swashbuckle.OData/Swashbuckle.OData.csproj
+++ b/Swashbuckle.OData/Swashbuckle.OData.csproj
@@ -77,10 +77,10 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE;CONTRACTS_FULL</DefineConstants>
+    <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <CodeContractsEnableRuntimeChecking>True</CodeContractsEnableRuntimeChecking>
+    <CodeContractsEnableRuntimeChecking>False</CodeContractsEnableRuntimeChecking>
     <CodeContractsRuntimeOnlyPublicSurface>False</CodeContractsRuntimeOnlyPublicSurface>
     <CodeContractsRuntimeThrowOnFailure>True</CodeContractsRuntimeThrowOnFailure>
     <CodeContractsRuntimeCallSiteRequires>False</CodeContractsRuntimeCallSiteRequires>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ environment:
        secure: EFTW/YldlkfUPVuAZTbv09gYi8MtEbZ6WZ6AU23f5Bg9BuCPN8wMAZxvOzycWGvK
 
 after_test: 
-- packages\OpenCover.4.6.519\tools\OpenCover.Console.exe -register:user -filter:"+[Swashbuckle.OData]* -[Swashbuckle.OData]System.*" -target:"packages\NUnit.ConsoleRunner.3.6.1\tools\nunit3-console.exe" -targetargs:"/noshadow /domain:single Swashbuckle.OData.Tests\bin\Debug\Swashbuckle.OData.Tests.dll" -output:coverage.xml
+- packages\OpenCover.4.6.519\tools\OpenCover.Console.exe -register:user -filter:"+[Swashbuckle.OData]* -[Swashbuckle.OData]System.*" -target:"packages\NUnit.ConsoleRunner.3.7.0\tools\nunit3-console.exe" -targetargs:"/noshadow /domain:single Swashbuckle.OData.Tests\bin\Debug\Swashbuckle.OData.Tests.dll" -output:coverage.xml
 - packages\coveralls.io.1.3.4\tools\coveralls.net.exe --opencover coverage.xml
 
 deploy:


### PR DESCRIPTION
Summary:
______________________________
I've updated nunit nuget packages + I've added NUnit3TestAdapeter to make tests runnable directly in visual studio. (VS 2017 in my case)
______________________________
WebAPI/OData allows us to define odata actions with parameters of type other than ODataActionParameters type. For example:
```csharp
public class EmailData
{
    public virtual string Title { get; set; }
    // , ...
}

public class EmailController : ODataController
{
    // action
    public async SendEmail(EmailData data)
    {
    }
}
```
So, I committed [MapToODataActionParameter won't raise an exception when odata action has no odata action parameter](https://github.com/rbeauchamp/Swashbuckle.OData/commit/582666c12fa8c071089f930b0e7c85a9c768a65b) because it's not a must have really.
______________________________
We might develop custom enable query attribute for several reasons. For example, I run queries async in my own customized action filter + We might add EnableQuery globally or at class level instead of action level. So I committed [Add support for global level enable query action filter](https://github.com/rbeauchamp/Swashbuckle.OData/commit/b0ac16f4c09581ad1da9bf5fec75622df4278247) This checks if any EnableQuery exists action's filter pipeline. This includes EnableQuery on action itself, on its class or global level of web api action filters. This accepts that only if return type of action is suitable for odata queries such as $filter, so it checks the return type to be a enumerable type. This is not a breaking change, as **previews behavior exists untouched**.
______________________________
[Bit framework](https://docs.bit-framework.com/) is a full stack C#/TypeScript/JavaScript framework which allows you to develop api/odata/background job/messaging on top of asp.net core and asp.net using owin abstractions. It has offline support for both Xamarin & Web clients and it has support for RAD components. It's open source and free to use with MIT license. We're very happy with what you've done in this amazing project (Swashbuckle.OData) and we'd like to use this project in our full stack framework. If you accept this PR, we can continue our contribution alongside you to make it even better.
**Let us know if any improvements can be done to this PR.**
Thanks for what you've done for us. Bit team.