### PR TITLE
ODataQueryOptions input properties should be excluded from output

### DIFF
--- a/Swashbuckle.OData.Tests/Fixtures/ODataQueryOptionsTests.cs
+++ b/Swashbuckle.OData.Tests/Fixtures/ODataQueryOptionsTests.cs
@@ -49,6 +49,8 @@ namespace Swashbuckle.OData.Tests.ODataQueryOptions
                 swaggerDocument.paths.TryGetValue("/odata/Products3({Id})", out pathItem2);
                 pathItem.Should().NotBeNull();
                 pathItem.get.Should().NotBeNull();
+                // Verify that ODataQueryOptions types are not in the definition
+                swaggerDocument.definitions.ContainsKey("ApplyQueryOption").Should().BeFalse();
 
                 await ValidationUtils.ValidateSwaggerJson();
             }

--- a/Swashbuckle.OData/Descriptions/ODataActionDescriptorMapperBase.cs
+++ b/Swashbuckle.OData/Descriptions/ODataActionDescriptorMapperBase.cs
@@ -162,7 +162,11 @@ namespace Swashbuckle.OData.Descriptions
             {
                 foreach (var parameterBinding in parameterBindings)
                 {
-                    Contract.Assume(parameterBinding != null);
+                    Contract.Assume(parameterBinding != null || parameterBinding.Descriptor != null);
+                    if(parameterBinding.Descriptor.IsODataLibraryType())
+                    {
+                        continue;
+                    }
                     parameterDescriptions.Add(CreateParameterDescriptionFromBinding(parameterBinding));
                 }
             }


### PR DESCRIPTION
Pull request to fix Issue rbeauchamp/Swashbuckle.OData#168

Hope that's all OK.



