### PR TITLE
Throw descriptive exception, missing ResolveConflictingActions (VS2015)

### DIFF
--- a/Swashbuckle.OData/ODataSwaggerProvider.cs
+++ b/Swashbuckle.OData/ODataSwaggerProvider.cs
@@ -152,10 +152,20 @@ namespace Swashbuckle.OData
 
                 var httpMethod = group.Key;
 
-                var apiDescription = group.Count() == 1
-                    ? group.First() : (_config.GetSwashbuckleOptions().ConflictingActionsResolver == null
-                                       ? throw new InvalidOperationException("ResolveConflictingActions is not configured for Swagger.")
-                                       : _config.GetSwashbuckleOptions().ConflictingActionsResolver(group));
+                ApiDescription apiDescription = null;
+
+                if (group.Count() == 1)
+                {
+                    apiDescription = group.First();
+                }
+                else if (_config.GetSwashbuckleOptions().ConflictingActionsResolver == null)
+                {
+                    throw new InvalidOperationException("ResolveConflictingActions is not configured for Swagger.");
+                }
+                else
+                {
+                    apiDescription = _config.GetSwashbuckleOptions().ConflictingActionsResolver(group);
+                }
 
                 Contract.Assume(apiDescription != null);
                 Contract.Assume(apiDescription.ParameterDescriptions != null);

--- a/Swashbuckle.OData/ODataSwaggerProvider.cs
+++ b/Swashbuckle.OData/ODataSwaggerProvider.cs
@@ -153,8 +153,9 @@ namespace Swashbuckle.OData
                 var httpMethod = group.Key;
 
                 var apiDescription = group.Count() == 1
-                    ? group.First()
-                    : _config.GetSwashbuckleOptions().ConflictingActionsResolver(group);
+                    ? group.First() : (_config.GetSwashbuckleOptions().ConflictingActionsResolver == null
+                                       ? throw new InvalidOperationException("ResolveConflictingActions is not configured for Swagger.")
+                                       : _config.GetSwashbuckleOptions().ConflictingActionsResolver(group));
 
                 Contract.Assume(apiDescription != null);
                 Contract.Assume(apiDescription.ParameterDescriptions != null);


### PR DESCRIPTION
Same as #170 but using a syntax that is supported by the build server. (#170 should be closed if this one gets merged and vice versa.)

When ResolveConflictingActions is not configured and an OData controller has more than one Get method, an InvalidOperationException with message ResolveConflictingActions is not configured for Swagger is thrown instead of a cryptic NullReferenceException.
Gives me a hint on how to solve issue #158 in my project.