### PR TITLE
Custom property resolver

### DIFF
--- a/Swashbuckle.OData.Tests/Fixtures/ModelSchemaTests.cs
+++ b/Swashbuckle.OData.Tests/Fixtures/ModelSchemaTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
+using System.Reflection;
 using System.Runtime.Serialization;
 using System.Threading.Tasks;
 using System.Web.OData;
@@ -46,9 +47,74 @@ namespace Swashbuckle.OData.Tests
             }
         }
 
+        [Test]
+        public async Task The_model_schema_matches_the_edm_model_with_default_property_resolver()
+        {
+            using (WebApp.Start(HttpClientUtils.BaseAddress, appBuilder => ConfigurationWithPropertyResolver(appBuilder, typeof(BrandsController), new DefaultProperyResolver())))
+            {
+                // Arrange
+                var httpClient = HttpClientUtils.GetHttpClient(HttpClientUtils.BaseAddress);
+                // Verify that the OData route in the test controller is valid
+                var result = await httpClient.GetAsync("/odata/Brands");
+                result.IsSuccessStatusCode.Should().BeTrue();
+
+                // Act
+                var swaggerDocument = await httpClient.GetJsonAsync<SwaggerDocument>("swagger/docs/v1");
+
+                // Assert
+                swaggerDocument.definitions.Should().ContainKey("Brand");
+                var brandSchema = swaggerDocument.definitions["Brand"];
+
+                brandSchema.properties.Should().ContainKey("id");
+                brandSchema.properties.Should().ContainKey("code");
+                brandSchema.properties.Should().NotContainKey("name");
+                brandSchema.properties.Should().NotContainKey("Name");
+                brandSchema.properties.Should().ContainKey("Something");
+
+                await ValidationUtils.ValidateSwaggerJson();
+            }
+        }
+
+        [Test]
+        public async Task The_model_schema_matches_the_edm_model_with_custom_property_resolver()
+        {
+            using (WebApp.Start(HttpClientUtils.BaseAddress, appBuilder => ConfigurationWithPropertyResolver(appBuilder, typeof(BrandsController), new ReflectedPropertyResolver())))
+            {
+                // Arrange
+                var httpClient = HttpClientUtils.GetHttpClient(HttpClientUtils.BaseAddress);
+                // Verify that the OData route in the test controller is valid
+                var result = await httpClient.GetAsync("/odata/Brands");
+                result.IsSuccessStatusCode.Should().BeTrue();
+
+                // Act
+                var swaggerDocument = await httpClient.GetJsonAsync<SwaggerDocument>("swagger/docs/v1");
+
+                // Assert
+                swaggerDocument.definitions.Should().ContainKey("Brand");
+                var brandSchema = swaggerDocument.definitions["Brand"];
+
+                brandSchema.properties.Should().ContainKey("Id");
+                brandSchema.properties.Should().ContainKey("Code");
+                brandSchema.properties.Should().NotContainKey("name");
+                brandSchema.properties.Should().NotContainKey("Name");
+                brandSchema.properties.Should().ContainKey("Description");
+
+                await ValidationUtils.ValidateSwaggerJson();
+            }
+        }
+
         private static void Configuration(IAppBuilder appBuilder, Type targetController)
         {
             var config = appBuilder.GetStandardHttpConfig(targetController);
+
+            config.MapODataServiceRoute("ODataRoute", "odata", GetEdmModel());
+
+            config.EnsureInitialized();
+        }
+
+        private static void ConfigurationWithPropertyResolver(IAppBuilder appBuilder, Type targetController, IProperyResolver properyResolver)
+        {
+            var config = appBuilder.GetStandardHttpConfig(null, swg => swg.SetProperyResolver(properyResolver), targetController);
 
             config.MapODataServiceRoute("ODataRoute", "odata", GetEdmModel());
 
@@ -87,6 +153,14 @@ namespace Swashbuckle.OData.Tests
         public IQueryable<Brand> GetBrands()
         {
             return Enumerable.Empty<Brand>().AsQueryable();
+        }
+    }
+
+    public class ReflectedPropertyResolver : IProperyResolver
+    {
+        public string ResolveName(MemberInfo memberInfo, string defaultName)
+        {
+            return memberInfo.Name;
         }
     }
 }

--- a/Swashbuckle.OData/ODataSwaggerDocsConfig.cs
+++ b/Swashbuckle.OData/ODataSwaggerDocsConfig.cs
@@ -9,6 +9,7 @@ using Swashbuckle.OData.Descriptions;
 using Swashbuckle.Swagger;
 using System.Xml.XPath;
 using System.Web.Http.Dispatcher;
+using System.Web.OData;
 
 namespace Swashbuckle.OData
 {
@@ -26,7 +27,7 @@ namespace Swashbuckle.OData
 
             Configuration = httpConfiguration;
             _swaggerDocsConfig = swaggerDocsConfig;
-            _includeNavigationProperties = false;            
+            _includeNavigationProperties = false;
             _documentFilters = new List<Func<IDocumentFilter>>();
             enableCache = false;
         }
@@ -99,7 +100,7 @@ namespace Swashbuckle.OData
         internal SwashbuckleOptions GetSwashbuckleOptions()
         {
             AddGlobalDocumentFilters();
-            AddODataDocumentFilters();                    
+            AddODataDocumentFilters();
 
             var swaggerProviderOptions = new SwaggerProviderOptions(
                 _swaggerDocsConfig.GetFieldValue<Func<ApiDescription, string, bool>>("_versionSupportResolver"),
@@ -120,7 +121,7 @@ namespace Swashbuckle.OData
                 _swaggerDocsConfig.GetFieldValue<Func<IEnumerable<ApiDescription>, ApiDescription>>("_conflictingActionsResolver"),
                 _swaggerDocsConfig.GetFieldValue<bool>("_applyFiltersToAllSchemas"),
                 _swaggerDocsConfig.GetFieldValue<IEnumerable<Func<XPathDocument>>>("_xmlDocFactories").Select(factory=>factory).ToList()
-            );            
+            );
 
             return new SwashbuckleOptions(swaggerProviderOptions);
         }
@@ -161,7 +162,7 @@ namespace Swashbuckle.OData
         private void AddGlobalDocumentFilters()
         {
             _swaggerDocsConfig.DocumentFilter<EnsureUniqueOperationIdsFilter>();
-        }  
+        }
 
         /// <summary>
         /// Gets the API versions. I'd rather not use reflection because the implementation may change, but can't find a better way.
@@ -193,6 +194,15 @@ namespace Swashbuckle.OData
         public void SetAssembliesResolver(IAssembliesResolver assembliesResolver)
         {
             System.Web.OData.TypeHelper.SetAssembliesResolver(assembliesResolver);
+        }
+
+        /// <summary>
+        /// Set the custom Property Resolver to be used instead of using the default one.
+        /// </summary>
+        /// <param name="propertyResolver">Cutrom proprty resolver.</param>
+        public void SetProperyResolver(IProperyResolver propertyResolver)
+        {
+            TypeHelper.SetProperyResolver(propertyResolver);
         }
     }
 }

--- a/Swashbuckle.OData/SchemaRegistryExtensions.cs
+++ b/Swashbuckle.OData/SchemaRegistryExtensions.cs
@@ -166,9 +166,7 @@ namespace Swashbuckle.OData
             Contract.Requires(currentProperty != null);
             Contract.Requires(edmProperty != null);
 
-            var dataMemberAttribute = currentProperty.GetCustomAttributes<DataMemberAttribute>()?.SingleOrDefault();
-
-            return !string.IsNullOrWhiteSpace(dataMemberAttribute?.Name) ? dataMemberAttribute.Name : edmProperty.Name;
+            return TypeHelper.GetPropertyName(currentProperty, edmProperty.Name);
         }
 
         private static bool IsResponseWithPrimiveTypeNotSupportedByJson(Type type, MessageDirection messageDirection)
@@ -196,12 +194,12 @@ namespace Swashbuckle.OData
         {
             Contract.Requires(type != null);
 
-            var isDelta = type.IsGenericType 
-                && type.GetGenericTypeDefinition() == typeof (Delta<>) 
-                && messageDirection == MessageDirection.Input;
-            var isSingleResult = type.IsGenericType 
-                && type.GetGenericTypeDefinition() == typeof (SingleResult<>) 
-                && messageDirection == MessageDirection.Output;
+            var isDelta = type.IsGenericType
+                          && type.GetGenericTypeDefinition() == typeof (Delta<>)
+                          && messageDirection == MessageDirection.Input;
+            var isSingleResult = type.IsGenericType
+                                 && type.GetGenericTypeDefinition() == typeof (SingleResult<>)
+                                 && messageDirection == MessageDirection.Output;
 
             return isDelta || isSingleResult;
         }


### PR DESCRIPTION
Added new feature "Custom property resolver". 
It provides flexible way resolve schema's property name instead of force using DataMemberAttribute.

Usage sample:
```
GlobalConfiguration.Configuration.EnableSwagger(c => {
    c.CustomProvider(defaultProvider => new ODataSwaggerProvider(defaultProvider, c, GlobalConfiguration.Configuration)
     .Configure(odataConfig =>
     {
         ...
         //Set custom ProperyResolver
         odataConfig.SetProperyResolver(new DefaultProperyResolver());
     }));
});
```