### PR TITLE
better align README w/sample app re:Custom Swagger Routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ config.AddCustomSwaggerRoute(customODataRoute, "/Customers({Id})/Orders")
     // The name of the parameter as it appears in the controller action
     .BodyParameter<Order>("order");
 ```
-The above route resolves to an `OrderController` action of:
+The above route resolves to an `OrdersController` (the last path segment defining the controller) and hits the `Post` action:
 ```csharp
 [ResponseType(typeof(Order))]
 public async Task<IHttpActionResult> Post([FromODataUri] int customerId, Order order)


### PR DESCRIPTION
due to a small typo, the original readme incorrectly referred to a controller that does not exist / would not be mapped to.

I also added a little extra clarification to explain how the controller is picked