### PR TITLE
fixed Issue #95  - DataMember Attribute

### DIFF
--- a/Swashbuckle.OData.Tests/Fixtures/DataMemberAttributeTests.cs
+++ b/Swashbuckle.OData.Tests/Fixtures/DataMemberAttributeTests.cs
@@ -1,0 +1,140 @@
+﻿using FluentAssertions;
+using Microsoft.OData.Edm;
+using Microsoft.Owin.Hosting;
+using NUnit.Framework;
+using Owin;
+using Swashbuckle.Application;
+using Swashbuckle.Swagger;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Text;
+using System.Threading.Tasks;
+using System.Web.Http;
+using System.Web.Http.Description;
+using System.Web.OData;
+using System.Web.OData.Builder;
+using System.Web.OData.Extensions;
+using System.Web.OData.Formatter;
+using System.Web.OData.Formatter.Deserialization;
+using System.Web.OData.Formatter.Serialization;
+using System.Web.OData.Routing;
+
+namespace Swashbuckle.OData.Tests
+{
+    public class DataMemberAttributeTests
+    {
+        [Test]
+        public async Task It_generates_a_valid_swagger_json_from_a_model_with_DataMemberAttribute()
+        {
+            Action<SwaggerDocsConfig> config = c => c.DocumentFilter<ApplyDataMemberAttributesDocumentation>();
+            using (WebApp.Start(HttpClientUtils.BaseAddress, appBuilder =>
+                        DataMemberAttributeModelSetup.ConfigurationWithFormatters(appBuilder,
+                            config,
+                            typeof(DataMemberAttributeModelSetup.DataMemberAttributeModelsController))))
+            {
+                // Access swagger doc first
+                await ValidationUtils.ValidateSwaggerJson();
+
+            }
+
+        }
+    }
+
+    public class ApplyDataMemberAttributesDocumentation : IDocumentFilter
+    {
+        public void Apply(SwaggerDocument swaggerDoc, SchemaRegistry schemaRegistry, IApiExplorer apiExplorer)
+        {
+            swaggerDoc.tags = new List<Tag>
+            {
+                new Tag { name = "DataMemberAttributeModels", description = "A Simple Model with a DataMemberAttribute on in." }
+            };
+        }
+    }
+
+    public class DataMemberAttributeModelSetup
+    {
+        public static void Configuration(IAppBuilder appBuilder, Action<SwaggerDocsConfig> unitTestConfigs, params Type[] targetControllers)
+        {
+            var config = new HttpConfiguration
+            {
+                IncludeErrorDetailPolicy = IncludeErrorDetailPolicy.Always
+            };
+
+            config = ConfigureWebApi(config);
+
+            ConfigureOData(appBuilder, targetControllers, config, unitTestConfigs);
+
+            config.EnsureInitialized();
+        }
+
+        public static void ConfigurationWithFormatters(IAppBuilder appBuilder, Action<SwaggerDocsConfig> unitTestConfigs, params Type[] targetControllers)
+        {
+            var config = new HttpConfiguration
+            {
+                IncludeErrorDetailPolicy = IncludeErrorDetailPolicy.Always
+            };
+
+            config = ConfigureWebApi(config);
+
+            var oDataRoute = ConfigureOData(appBuilder, targetControllers, config, unitTestConfigs);
+            var rootContainer = config.GetODataRootContainer(oDataRoute);
+
+            config.Formatters.InsertRange(0, ODataMediaTypeFormatters.Create(new DefaultODataSerializerProvider(rootContainer), new DefaultODataDeserializerProvider(rootContainer)));
+
+            config.EnsureInitialized();
+        }
+
+        public static HttpConfiguration ConfigureWebApi(HttpConfiguration config)
+        {
+            config.MapHttpAttributeRoutes();
+
+            return config;
+        }
+
+        private static ODataRoute ConfigureOData(IAppBuilder appBuilder, Type[] targetController, HttpConfiguration config, Action<SwaggerDocsConfig> swaggerDocsConfig)
+        {
+            config = appBuilder.ConfigureHttpConfig(config, swaggerDocsConfig, null, targetController);
+
+            return config.MapODataServiceRoute("odata", "odata", GetEdmModel());
+        }
+
+        public static IEdmModel GetEdmModel()
+        {
+            var builder = new ODataConventionModelBuilder();
+
+            builder.EntitySet<DataMemberAttributeModel>("DataMemberAttributeModels");
+
+            return builder.GetEdmModel();
+        }
+        [DataContract]
+        public class DataMemberAttributeModel
+        {
+            [DataMember(Name = "id")]
+            [Key]
+            public int Id { get; set; }
+            [DataMember(Name = "differentName")]
+            public string Variation { get; set; }
+        }
+
+        public class DataMemberAttributeModelsController : ODataController
+        {
+            [HttpGet]
+            [ODataRoute("DataMemberAttributeModels")]
+            [EnableQuery]
+            public IQueryable<DataMemberAttributeModel> DataMemberAttributeModels()
+            {
+                IEnumerable<DataMemberAttributeModel> dataMemberAttributeModels = new[]
+                {
+                new DataMemberAttributeModel { Id=1, Variation = "a"},
+                new DataMemberAttributeModel { Id=2, Variation = "b"},
+                new DataMemberAttributeModel { Id=3, Variation = "c"},
+                new DataMemberAttributeModel { Id=4, Variation = "d"}
+                };
+                return dataMemberAttributeModels.AsQueryable();
+            }
+        }
+    }
+}

--- a/Swashbuckle.OData.Tests/Fixtures/DataMemberAttributeTests.cs
+++ b/Swashbuckle.OData.Tests/Fixtures/DataMemberAttributeTests.cs
@@ -117,6 +117,10 @@ namespace Swashbuckle.OData.Tests
             public int Id { get; set; }
             [DataMember(Name = "differentName")]
             public string Variation { get; set; }
+            [DataMember(Name = "sameNameCamelCasing")]
+            public string SameNameCamelCasing { get; set; }
+            [DataMember(Name = "SameName")]
+            public string SameName { get; set; }
         }
 
         public class DataMemberAttributeModelsController : ODataController

--- a/Swashbuckle.OData.Tests/Swashbuckle.OData.Tests.csproj
+++ b/Swashbuckle.OData.Tests/Swashbuckle.OData.Tests.csproj
@@ -148,6 +148,7 @@
     <Compile Include="Containment\ODataModels.cs" />
     <Compile Include="Containment\Program.cs" />
     <Compile Include="ContentType.cs" />
+    <Compile Include="Fixtures\DataMemberAttributeTests.cs" />
     <Compile Include="Fixtures\SummaryTests.cs" />
     <Compile Include="Fixtures\ParameterTests\DecimalParameterAndResponseTests.cs" />
     <Compile Include="Fixtures\ModelSharedBetweenODataAndWebApiTests.cs" />

--- a/Swashbuckle.OData/SchemaRegistryExtensions.cs
+++ b/Swashbuckle.OData/SchemaRegistryExtensions.cs
@@ -129,6 +129,7 @@ namespace Swashbuckle.OData
         private static void ApplyEdmModelPropertyNamesToSchema(SchemaRegistry registry, IEdmModel edmModel, Type type)
         {
             var entityReference = registry.GetOrRegister(type);
+            var hasDataMemberAttribute = false;
             if (entityReference.@ref != null)
             {
                 var definitionKey = entityReference.@ref.Replace("#/definitions/", string.Empty);
@@ -150,6 +151,7 @@ namespace Swashbuckle.OData
                             // this can happen if the DataMemberAttributes Name is the same as the Property...
                             if (originalProperty != null)
                             {
+                                hasDataMemberAttribute = true;
                                 key = originalProperty.Name;
                             }
                             else
@@ -162,7 +164,10 @@ namespace Swashbuckle.OData
                             key = property.Key;
                         }
                         var currentProperty = type.GetProperty(key, BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance);
-                        var edmPropertyName = GetEdmPropertyName(currentProperty, edmType);
+
+
+                        var edmPropertyName = GetEdmPropertyName(currentProperty, edmType, hasDataMemberAttribute ? property.Key : currentProperty.Name);
+
                         if (edmPropertyName != null)
                         {
                             edmProperties.Add(edmPropertyName, property.Value);
@@ -173,12 +178,12 @@ namespace Swashbuckle.OData
             }
         }
 
-        private static string GetEdmPropertyName(MemberInfo currentProperty, IEdmStructuredType edmType)
+        private static string GetEdmPropertyName(MemberInfo currentProperty, IEdmStructuredType edmType, string propertyName)
         {
             Contract.Requires(currentProperty != null);
             Contract.Requires(edmType != null);
 
-            var edmProperty = edmType.Properties().SingleOrDefault(property => property.Name.Equals(currentProperty.Name, StringComparison.CurrentCultureIgnoreCase));
+            var edmProperty = edmType.Properties().SingleOrDefault(property => property.Name.Equals(propertyName, StringComparison.CurrentCultureIgnoreCase));
 
             return edmProperty != null ? GetPropertyNameForEdmModel(currentProperty, edmProperty) : null;
         }

--- a/Swashbuckle.OData/SchemaRegistryExtensions.cs
+++ b/Swashbuckle.OData/SchemaRegistryExtensions.cs
@@ -147,10 +147,14 @@ namespace Swashbuckle.OData
                                 .OfType<DataMemberAttribute>()
                                 .Any(x => x.Name == property.Key))
                                 .FirstOrDefault();
-                            // shouldn't need this but just in case...
+                            // this can happen if the DataMemberAttributes Name is the same as the Property...
                             if (originalProperty != null)
                             {
                                 key = originalProperty.Name;
+                            }
+                            else
+                            {
+                                key = property.Key;
                             }
                         }
                         else

--- a/Swashbuckle.OData/SchemaRegistryExtensions.cs
+++ b/Swashbuckle.OData/SchemaRegistryExtensions.cs
@@ -139,7 +139,25 @@ namespace Swashbuckle.OData
                     var edmProperties = new Dictionary<string, Schema>();
                     foreach (var property in schemaDefinition.properties)
                     {
-                        var currentProperty = type.GetProperty(property.Key, BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance);
+                        string key = string.Empty;
+                        if (type.IsDefined(typeof(DataContractAttribute), true))
+                        {
+                            var originalProperty = type.GetProperties()
+                                .Where(p => p.GetCustomAttributes(typeof(DataMemberAttribute), true)
+                                .OfType<DataMemberAttribute>()
+                                .Any(x => x.Name == property.Key))
+                                .FirstOrDefault();
+                            // shouldn't need this but just in case...
+                            if (originalProperty != null)
+                            {
+                                key = originalProperty.Name;
+                            }
+                        }
+                        else
+                        {
+                            key = property.Key;
+                        }
+                        var currentProperty = type.GetProperty(key, BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance);
                         var edmPropertyName = GetEdmPropertyName(currentProperty, edmType);
                         if (edmPropertyName != null)
                         {


### PR DESCRIPTION
where a Swagger Document would not be generated if a property had a DataMember attribute with a different name(not including casing) than the property itself.
also added a Test.