### PR TITLE
fix for: Entity bound actions can have ODataActionParameters type parameters only

### DIFF
--- a/Swashbuckle.OData/Descriptions/MapToODataActionParameter.cs
+++ b/Swashbuckle.OData/Descriptions/MapToODataActionParameter.cs
@@ -15,12 +15,14 @@ namespace Swashbuckle.OData.Descriptions
 
             if (swaggerParameter.@in == "body" && swaggerParameter.schema != null && swaggerParameter.schema.type == "object")
             {
-                var odataActionParametersDescriptor = actionDescriptor.GetParameters().SingleOrDefault(descriptor => descriptor.ParameterType == typeof (ODataActionParameters));
-                Contract.Assume(odataActionParametersDescriptor != null);
-                return new ODataActionParameterDescriptor(odataActionParametersDescriptor.ParameterName, typeof(ODataActionParameters), !required.Value, swaggerParameter.schema, odataActionParametersDescriptor)
+                var odataActionParametersDescriptor = actionDescriptor.GetParameters().SingleOrDefault(descriptor => descriptor.GetCustomAttributes<FromODataUriAttribute>().Count == 0);
+                if (odataActionParametersDescriptor == null) {
+                    return null;
+                }
+                return new ODataActionParameterDescriptor(odataActionParametersDescriptor.ParameterName, odataActionParametersDescriptor.ParameterType, !required.Value, swaggerParameter.schema, odataActionParametersDescriptor)
                 {
                     Configuration = actionDescriptor.ControllerDescriptor.Configuration,
-                    ActionDescriptor = actionDescriptor
+                    ActionDescriptor = actionDescriptor,
                 };
             }
             return null;


### PR DESCRIPTION
This is a fix #187 